### PR TITLE
Add simulation mode status message to app

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -266,3 +266,11 @@ select {
   margin: 0 0 0 5px;
   width: auto;
 }
+
+.simulation-status {
+  font-family: 'Chivo', sans-serif;
+  font-size: 0.875rem;
+  position: absolute;
+  top: 5px;
+  right: 10px;
+}

--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -16,6 +16,7 @@ const template = `
   <div id="dashboard" v-bind:style="dashStyle">
     <header>
       <h1 v-bind:style="headingStyle"><span class="hemoji">⚡️</span>electric io</h1>
+      <div v-if="simulating" class="simulation-status">⚠️ Using simulated data</div>
     </header>
 
     <main>
@@ -33,6 +34,7 @@ const initialData = function() {
     },
     messages: [],
     deviceList: [],
+    simulating: SIMULATING
   }
 };
 

--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -16,7 +16,7 @@ const template = `
   <div id="dashboard" v-bind:style="dashStyle">
     <header>
       <h1 v-bind:style="headingStyle"><span class="hemoji">⚡️</span>electric io</h1>
-      <div v-if="simulating" class="simulation-status">⚠️ Using simulated data</div>
+      <div v-if="simulating" :style="headingStyle" class="simulation-status">⚠️ Using simulated data</div>
     </header>
 
     <main>
@@ -44,7 +44,7 @@ export default Vue.component('main-app', {
   data: initialData,
   computed: {
     dashStyle: function() {
-      // saveSettings() uses Formdata, which converts booleans to strings, so
+      // saveSettings() uses FormData, which converts booleans to strings, so
       // there's a chance we might get a string. Let's convert it back!
       if (typeof this.dashboard.bgImageRepeat !== "undefined") {
         var bgImageRepeatBool = JSON.parse(this.dashboard.bgImageRepeat);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const path = require('path');
 const MinifyPlugin = require('babel-minify-webpack-plugin');
 const mode = process.env.NODE_ENV === 'development' ? 'development' : 'production';
@@ -14,6 +15,11 @@ module.exports = {
     rules: [
       { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' }
     ]
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'SIMULATING': process.env.SIMULATING
+    })
+  ]
 };
 


### PR DESCRIPTION
This PR creates a Simulation mode status as described in issue #22.

- It uses webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/) to expose the `process.env.SIMULATING` environment variable to the Vue application.
- If `SIMULATING` is `true`, a small status message is shown, situated inside the `<header>` but pinned to the top right of the page.
- Further enhancement might be some improved styling for the message. I considered putting it inside a bar with a solid background, but didn't want to clash with papayawhip❤️ or mess with the layout too much!
- I've tested that DefinePlugin works on Glitch with a [simple test project](https://glitch.com/edit/#!/vine-structure) that uses an .env file with `SIMULATING=true`.