### PR TITLE
Fixes #12: Add ability to change app title

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,6 +12,7 @@ const createDashboardFileIfNotExists = function(callback) {
         blockSize: [250, 200],
         bgColor: 'papayawhip',
         tiles: [],
+        title: '\u26a1electric io',
         bgImageUrl: '',
         bgImageRepeat: 'true'
       }

--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -15,7 +15,7 @@ import contrastColor from '../lib/colorContraster.js';
 const template = `
   <div id="dashboard" v-bind:style="dashStyle">
     <header>
-      <h1 v-bind:style="headingStyle"><span class="hemoji">⚡️</span>electric io</h1>
+      <h1 v-bind:style="headingStyle">{{this.dashboard.title}}</h1>
       <div v-if="simulating" :style="headingStyle" class="simulation-status">⚠️ Using simulated data</div>
     </header>
 

--- a/public/js/components/settings.js
+++ b/public/js/components/settings.js
@@ -6,6 +6,9 @@ const template = `
   <div class="card" id="settings">
     <h2>Settings</h2>
     <form v-on:submit.prevent="onSaveSettings">
+      <label>App Title
+        <input type="text" name="title" v-bind:value="dashboard.title" />
+      </label>
       <label>Background Color
         <input type="text" name="bgColor" v-bind:value="dashboard.bgColor" />
       </label>


### PR DESCRIPTION
Add ability to change the app title via the app settings widget. As a side effect, support for the default emoji styling was removed. The issue has been reported in issue #30.

Closes #12 