### PR TITLE
README.md: Add a section on transferring dashboard settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ Fields:
 
 Got ideas for more cards? Open an issue on this repo and let me know! 👀
 
+## Transferring dashboard settings
+
+electric-io saves your dashboard configuration to `./.data/dashboard.json`. To safely transfer this elsewhere, stop the source and destination electric-io instances and copy `dashboard.json` across.
+
+```
+# With both the source and destination electric-io instances stopped
+cp ./electric-io-testing/.data/dashboard.json ./electric-io-production/.data/dashboard.json
+```
+
+The transferred settings should show up when electric-io is started again.
+
 ## Locking your dashboard
 
 A common thing you might want to do is to share your dashboard with folks without them changing things against your permission. If you'd like to temporarily 'lock' your dashboard, place the following line in your `./.env` file:


### PR DESCRIPTION
Hello and greetings,

This PR addresses issue #13. It seems possible to transfer the configuration live, but I believe it'd be best if a user stops both instances so that the configuration remains in a consistent state.

Addendum: I wanted to be sure that I didn't break any user trying this, so I spun up an impromptu
Docker container that runs two electric-io instances in parallel. Instructions for fully reproducing and tearing down are embedded in the Dockerfile here:

Dockerfile: https://gist.github.com/davidk/059e10b6fc04aa02bea058c7dfda66b8

Addendum 2: As I am uncool and without bitmoji, I submit this extremely friendly :cat2: in its stead. Spotted in Berkeley, California (if by kismet you meet it, say hi over and over in the dorkiest way possible to be greeted with a boop):

![a cat lounging in the sun](https://user-images.githubusercontent.com/36493/40884518-e6d1834a-66c9-11e8-9986-9787210ff503.jpg)

