### PR TITLE
Try and parse strings to numbers

### DIFF
--- a/public/js/components/NumberCard.vue
+++ b/public/js/components/NumberCard.vue
@@ -25,7 +25,7 @@ export default {
     messages: function() {
       const lastMessage = this.messages.pop();
       this.number = lastMessage
-        ? lastMessage[this.tile.property].toFixed(1)
+        ? parseFloat(lastMessage[this.tile.property]).toFixed(1)
         : 0;
     }
   },


### PR DESCRIPTION
By default, the number card throws an error if a string is passed as the data field. We can use `parseFloat` to try and get at the number if it's a string.