### PR TITLE
Update contributing list of contents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,17 @@ Hey thanks for your interest in contributing to this project! I really appreciat
 This page should get you up and running with how to run locally and how to adhere to this project's style guide also.
 
 1. [Installation](#installation)
-   1. [With a real Azure IoT Hub](#with-a-real-azure-iot-hub)
-   2. [With the device and hub simulator](#with-the-built-in-device-and-hub-simulator)
-2. [Style Guide](#style-guide-for-contributing-code)
+   - [With a real Azure IoT Hub](#with-a-real-azure-iot-hub)
+   - [With the device and hub simulator](#with-the-built-in-device-and-hub-simulator)
+2. [Style Guide](#style-guide)
+   - [Tests](#tests)
+   - [Mobile support](#mobile-support)
+3. [Pull Requests](#pull-requests)
+   - [Avoiding merge conflicts](#avoiding-merge-conflicts)
 
 ## Installation
 
-When developing electric-dreams locally, you have two options for ensuring you can test your code with incoming data. You can use a real Azure IoT Hub for connecting to, or you can use the ready made simulator instead.
+When developing electric-io locally, you have two options for ensuring you can test your code with incoming data. You can use a real Azure IoT Hub for connecting to, or you can use the ready made simulator instead.
 
 ### With a real Azure IoT Hub
 
@@ -88,7 +92,7 @@ Example payload:
 }
 ```
 
-## Code Style
+## Style Guide
 
 ESLint is installed by default with this repository, and many IDEs will automatically "fix" your code to match the expected style. Don't worry if your editor doesn't do this as there is also a git pre-commit hook that will run the linter when you commit.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ This page should get you up and running with how to run locally and how to adher
    - [Tests](#tests)
    - [Mobile support](#mobile-support)
 3. [Pull Requests](#pull-requests)
-   - [Avoiding merge conflicts](#avoiding-merge-conflicts)
+   - [Avoiding merge conflicts](#merge-conflicts)
 
 ## Installation
 


### PR DESCRIPTION
Hi! This PR relates to CONTRIBUTING.md

- Updated the list of contents
- Fixed a broken link in the list of contents
- Changed a reference from `electric-dreams` to `electric-io`

I also noticed that this document has a lot of overlap with README, particularly the installation part. Perhaps we could just link the reader back to README for this part? I haven't included that change in this PR, but it's something that might be worth discussing :mega: