### PR TITLE
tell nodemon to ignore frontend and test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,5 +99,11 @@
         "pre-commit": "pretty-quick --staged"
       }
     }
+  },
+  "nodemonConfig": {
+    "ignore": [
+      "test/*",
+      "public/*"
+    ]
   }
 }


### PR DESCRIPTION
Each time webpack rebuilds the front-end files, it triggers nodemon to bounce the server. This produces a longer delay in the developing feedback cycle, especially when developing against a live IoT Hub connection. A server bounce will trigger an IoT Hub reconnection and the server is not fully up and available until that is complete.

I added some configuration to the package json to tell nodemon to ignore both the `test` dir and the `public` dir to speed up local development.

![bitmoji](https://render.bitstrips.com/v2/cpanel/fc767834-5bcb-4a0b-bd9c-70fb3cb53399-8016a622-e09b-4505-8856-7726a074b1f9-v1.png?transparent=1&palette=1&width=246)