### PR TITLE
Use vue-a11y-dialog instead of alert to “remove card” (closes #21)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,6 +1875,11 @@
       "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
       "dev": true
     },
+    "a11y-dialog": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/a11y-dialog/-/a11y-dialog-5.2.0.tgz",
+      "integrity": "sha512-vymlarVdoDKNwQPq513D5IANZu7fdOiWjQJG0FuEFI77RfJUGrxpfI6puwXy7hxKmVTSf4bNq6ZgCb+EikIl8g=="
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -10145,6 +10150,11 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
+    "portal-vue": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-1.5.1.tgz",
+      "integrity": "sha512-7T0K+qyY8bnjnEpQTiLbGsUaGlFcemK9gLurVSr6x1/qzr2HkHDNCOz5i+xhuTD1CrXckf/AGeCnLzvmAHMOHw=="
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -12700,6 +12710,15 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.3.tgz",
       "integrity": "sha512-yftjtahz4UTAtOlXXuw7UaYD86fWrMDAAzqTdqJJx2FIBqcPmBN6kPBHiBJFGaQELVblb5ijbFMXsx0i0F7q3g=="
+    },
+    "vue-a11y-dialog": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/vue-a11y-dialog/-/vue-a11y-dialog-0.4.2.tgz",
+      "integrity": "sha512-GFXVKmbR5XkZ2+ZnEAJJzOMH6kC0V4/2WSlnA97FL6se3/AA0uCc17Xkb3bBu0iG3WpC4R98dG+UWHj7WiuJNQ==",
+      "requires": {
+        "a11y-dialog": "^5.2.0",
+        "portal-vue": "^1.5.1"
+      }
     },
     "vue-focus": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "marked": "0.6.0",
     "socket.io": "2.2.0",
     "vue": "2.6.3",
+    "vue-a11y-dialog": "^0.4.2",
     "vue-focus": "2.1.0"
   },
   "engines": {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -24,13 +24,16 @@ p {
 }
 
 form {
-  margin-bottom: 25px;
   background-color: cyan;
   padding: 15px;
   display: inline-block;
   width: 100%;
   max-width: 340px;
   border-radius: 3px;
+}
+
+form:not(:last-child) {
+  margin-bottom: 25px;
 }
 
 input,
@@ -123,12 +126,54 @@ h1 .hemoji {
   font-family: "Chivo", sans-serif;
 }
 
-.card button,
-.card .button,
-.card input[type="submit"] {
+button {
+  -webkit-appearance: none;
+  appearance: none;
+  padding: 0;
+  border: none;
+  color: currentColor;
+  background-color: #fff;
+  font: inherit;
+}
+
+button::-moz-focus-inner {
+  padding: 0;
+  border-style: none;
+}
+
+.inline-button {
+  padding: 5px;
+  border: 1px solid #fff;
+  border-radius: 3px;
+  font-size: 10px;
+}
+
+/*
+1. Stops following elements from covering the focus outline.
+*/
+.inline-button:focus {
+  outline: none;
+  box-shadow: 0 0 0 1px goldenrod;
+  transform: rotate(0); /* 1. */
+}
+
+.inline-button:hover {
+  border-color: currentColor;
+}
+
+.edit-button {
+  color: #00f;
+}
+
+.delete-button {
+  color: #da2727;
+  font-weight: bold;
+}
+
+.action-button {
   font-family: "Chivo", sans-serif;
-  border: 0;
-  background: #5786c1;
+  border: none;
+  background-color: #5786c1;
   color: white;
   padding: 8px 14px;
   font-weight: normal;
@@ -140,35 +185,24 @@ h1 .hemoji {
   cursor: pointer;
   /* needed for anchors */
   position: relative;
-  box-shadow: 1px 0px #3a587f, 0px 1px #4171ae, 2px 1px #3a587f, 1px 2px #4171ae,
+  box-shadow: 1px 0 #3a587f, 0 1px #4171ae, 2px 1px #3a587f, 1px 2px #4171ae,
     3px 2px #3a587f, 2px 3px #4171ae, 4px 3px #3a587f, 3px 4px #4171ae,
     5px 4px #3a587f, 4px 5px #4171ae, 6px 5px #3a587f, 5px 6px #4171ae;
 }
 
-.card button:hover,
-.card .button:hover,
-.card .button.hover,
-.card input[type="submit"]:hover,
-.card input[type="submit"].hover {
+.action-button:hover {
   transform: translate(2px, 2px);
-  box-shadow: 1px 0px #3a587f, 0px 1px #4171ae, 2px 1px #3a587f, 1px 2px #4171ae,
+  box-shadow: 1px 0 #3a587f, 0 1px #4171ae, 2px 1px #3a587f, 1px 2px #4171ae,
     3px 2px #3a587f, 2px 3px #4171ae, 4px 3px #3a587f, 3px 4px #4171ae;
 }
 
-.card button:focus,
-.card button.focus,
-.card .button.focus,
-.card .button:focus {
+.action-button:focus {
   border: 2px solid #333;
 }
 
-.card button:active,
-.card .button:active,
-.card .button.active,
-.card input[type="submit"]:active,
-.card input[type="submit"].active {
+.action-button:active {
   transform: translate(4px, 4px);
-  box-shadow: 0px 0px;
+  box-shadow: none;
 }
 
 .card.dragging:hover {
@@ -187,32 +221,7 @@ h1 .hemoji {
   margin-top: -12px;
   margin-right: -10px;
   float: right;
-  display: inline;
-}
-
-button.edit {
-  color: #0000ff;
-}
-
-button.edit,
-button.edit:hover,
-button.delete,
-button.delete:hover {
-  transform: none;
-  background-color: white;
-  border: none;
-  cursor: pointer;
-  box-shadow: none;
-  font-size: 10px;
-  float: left;
-  padding: 5px;
-}
-
-button.edit:focus,
-button.delete:focus,
-button.edit:hover,
-button.delete:hover {
-  border: 1px solid #0000ff;
+  display: flex;
 }
 
 .card p.status {
@@ -221,13 +230,13 @@ button.delete:hover {
   font-size: 12px;
 }
 
-p.error,
-button.delete {
-  color: #da2727;
+.card p.status:empty {
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
-button.delete {
-  font-weight: bold;
+p.error {
+  color: #da2727;
 }
 
 p.success {
@@ -369,4 +378,79 @@ select {
   padding: 0;
   position: absolute;
   width: 1px;
+}
+
+/*
+a11y-dialog styling layer
+http://edenspiekermann.github.io/a11y-dialog/#styling-layer
+*/
+
+.modal-wrapper {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+}
+
+.modal {
+  pointer-events: all;
+}
+
+.modal__title {
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.modal__close-button {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  font-size: 10px;
+  font-weight: bold;
+}
+
+dialog {
+  position: relative;
+  padding: 15px;
+  border: 2px solid #222;
+  border-radius: 6px;
+}
+
+/**
+ * When the native `<dialog>` element is supported, the overlay is implied and
+ * can be styled with `::backdrop`, which means the DOM one should be removed.
+ *
+ * The `data-a11y-dialog-native` attribute is set by the script when the
+ * `<dialog>` element is properly supported.
+ *
+ * Feel free to replace `:first-child` with the overlay selector you prefer.
+ */
+[data-a11y-dialog-native] > :first-child {
+  display: none;
+}
+
+/**
+ * When the `<dialog>` element is not supported, its default display is `inline`
+ * which can cause layout issues. This makes sure the dialog is correctly
+ * displayed when open.
+ */
+dialog[open] {
+  display: block;
+}
+
+/**
+ * When the native `<dialog>` element is not supported, the script toggles the
+ * `aria-hidden` attribute on the container. If `aria-hidden` is set to `true`,
+ * the container should be hidden entirely.
+ *
+ * Feel free to replace `.dialog-container` with the container selector you
+ * prefer.
+ */
+.dialog-container[aria-hidden="true"] {
+  display: none;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,24 +1,29 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <title>electric io</title>
+    <meta name="description" content="Device IO made easy with Glitch" />
+    <link
+      id="favicon"
+      rel="icon"
+      href="https://glitch.com/edit/favicon-app.ico"
+      type="image/x-icon"
+    />
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Chivo|Nanum+Pen+Script"
+      rel="stylesheet"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/css/style.css" />
+  </head>
 
-<head>
-  <title>electric io</title>
-  <meta name="description" content="Device IO made easy with Glitch">
-  <link id="favicon" rel="icon" href="https://glitch.com/edit/favicon-app.ico" type="image/x-icon">
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <link href="https://fonts.googleapis.com/css?family=Chivo|Nanum+Pen+Script" rel="stylesheet">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/style.css">
-</head>
+  <body>
+    <div id="app"></div>
+    <div id="dialog-root" class="modal-wrapper"></div>
 
-<body>
-
-  <div id="app"></div>
-
-  <script src="/js/dist/vendors~main.bundle.js"></script>
-  <script src="/js/dist/main.bundle.js"></script>
-
-</body>
-
+    <script src="/js/dist/vendors~main.bundle.js"></script>
+    <script src="/js/dist/main.bundle.js"></script>
+  </body>
 </html>

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -7,10 +7,25 @@
   >
     <div v-if="showChildCard">
       <div v-if="showControls" class="controls">
-        <button class="edit" ref="editButton" v-on:click="onEdit">edit</button>
-        <button class="delete" v-on:click="onDelete(tile.id)">X</button>
+        <button
+          class="inline-button edit-button"
+          ref="editButton"
+          v-on:click="onEdit"
+        >
+          edit
+        </button>
+
+        <button
+          class="inline-button delete-button"
+          aria-label="Remove card"
+          @click="openCardDeleteModal()"
+        >
+          X
+        </button>
       </div>
+
       <h2 v-if="tile.title">{{ tile.title }}</h2>
+
       <component
         v-bind:is="childCard"
         v-bind:tile="tile"
@@ -19,6 +34,7 @@
       >
       </component>
     </div>
+
     <card-form
       v-if="showForm"
       v-bind:editing="editing"
@@ -28,6 +44,39 @@
       v-on:save-settings="onSaveSettings"
     >
     </card-form>
+
+    <a11y-dialog
+      id="app-dialog"
+      app-root="#app"
+      dialog-root="#dialog-root"
+      :class-names="{
+        base: 'modal',
+        title: 'modal__title',
+        closeButton: 'inline-button modal__close-button'
+      }"
+      @dialog-ref="assignDialogRef"
+      close-button-label="Close the “Remove card” dialog"
+    >
+      <template v-slot:title>
+        <span>Remove card</span>
+      </template>
+
+      <template v-slot:closeButtonContent>
+        <span>X</span>
+      </template>
+
+      <div>
+        <p>Oh, do you really want to remove this card?</p>
+
+        <button
+          class="button action-button"
+          type="button"
+          @click="deleteTile(tile.id)"
+        >
+          Yes, remove it
+        </button>
+      </div>
+    </a11y-dialog>
   </div>
 </template>
 
@@ -50,7 +99,7 @@ export default {
     StickerCard,
     TextCard
   },
-  data: function() {
+  data() {
     return {
       editing: false,
       dragging: false,
@@ -58,10 +107,15 @@ export default {
       y: this.tile.position[1],
       x: this.tile.position[0],
       offsetY: 0,
-      offsetX: 0
+      offsetX: 0,
+      dialog: null
     };
   },
   methods: {
+    assignDialogRef(dialog) {
+      this.dialog = dialog;
+    },
+
     onMouseDown: function(event) {
       const allowedModes = ["unlocked", "demo"];
       const excludedNodes = ["INPUT", "TEXTAREA", "SELECT", "LABEL"];
@@ -95,12 +149,13 @@ export default {
     onEdit: function() {
       this.editing = true;
     },
-    onDelete: function(tileId) {
-      const message = "Oh, do you really want to remove this card?";
-      const confirm = window.confirm(message);
-      if (confirm) {
-        this.$emit("tile-delete", tileId);
+    openCardDeleteModal() {
+      if (this.dialog) {
+        this.dialog.show();
       }
+    },
+    deleteTile(tileId) {
+      this.$emit("tile-delete", tileId);
     },
     onSaveSettings: function(event) {
       this.editing = false;

--- a/public/js/components/ButtonCard.vue
+++ b/public/js/components/ButtonCard.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <button v-on:click="onClick">{{ tile.buttonText }}</button>
+    <button class="action-button" v-on:click="onClick">
+      {{ tile.buttonText }}
+    </button>
     <p v-bind:class="statusClass">{{ statusText }}</p>
   </div>
 </template>

--- a/public/js/components/CardForm.vue
+++ b/public/js/components/CardForm.vue
@@ -17,7 +17,7 @@
 
       <form-fields :tile="tile" :deviceList="deviceList" />
 
-      <input type="submit" value="save" />
+      <input class="action-button" type="submit" value="save" />
     </form>
   </div>
 </template>

--- a/public/js/components/DashboardSettings.vue
+++ b/public/js/components/DashboardSettings.vue
@@ -1,32 +1,54 @@
 <template>
-  <div class="card settings" :class="{'settings--closed': !settingsPanelOpen}">
+  <div
+    class="card settings"
+    :class="{ 'settings--closed': !settingsPanelOpen }"
+  >
     <div class="settings__header">
-      <button class="settings__toggle-btn" @click="onToggleSettingsPanel" :aria-expanded="settingsPanelOpen ? 'true' : 'false'" aria-labelledby="settings-toggle-label">
-        <span class="screen-reader-only" id="settings-toggle-label">{{ settingsPanelOpen ? 'Close settings panel' : 'Open settings panel' }}</span>
-        <span aria-hidden="true">{{ settingsPanelOpen ? '&rarr;' : '⚙️' }}</span>
+      <button
+        class="settings__toggle-btn"
+        @click="onToggleSettingsPanel"
+        :aria-expanded="settingsPanelOpen ? 'true' : 'false'"
+        aria-labelledby="settings-toggle-label"
+      >
+        <span class="screen-reader-only" id="settings-toggle-label">{{
+          settingsPanelOpen ? "Close settings panel" : "Open settings panel"
+        }}</span>
+        <span aria-hidden="true">{{
+          settingsPanelOpen ? "&rarr;" : "⚙️"
+        }}</span>
       </button>
       <h2 class="settings__title">Settings</h2>
     </div>
     <div class="settings__body">
       <form v-on:submit.prevent="onSaveSettings">
-        <label>App Title
+        <label
+          >App Title
           <input type="text" name="title" :value="dashboard.title" />
         </label>
-        <label>Background Color
+        <label
+          >Background Color
           <input type="text" name="bgColor" v-bind:value="dashboard.bgColor" />
         </label>
-        <label>Background Image URL
+        <label
+          >Background Image URL
           <input type="text" name="bgImageUrl" :value="dashboard.bgImageUrl" />
         </label>
         <label class="settings__checkbox-label">
           <span>Repeat background image?</span>
-          <input class="settings__checkbox" type="checkbox" name="bgImageRepeat" :value="dashboard.bgImageRepeat" v-model="dashboard.bgImageRepeat" />
+          <input
+            class="settings__checkbox"
+            type="checkbox"
+            name="bgImageRepeat"
+            :value="dashboard.bgImageRepeat"
+            v-model="dashboard.bgImageRepeat"
+          />
         </label>
-        <input type="submit" value="save"/>
+        <input class="action-button" type="submit" value="save" />
       </form>
       <h3>New Card</h3>
       <form v-on:submit.prevent="onCreateCard">
-        <label>Card Type
+        <label
+          >Card Type
           <select name="type">
             <option value="button">button</option>
             <option value="lineChart">line chart</option>
@@ -35,23 +57,23 @@
             <option value="text">text</option>
           </select>
         </label>
-        <input type="submit" value="create"/>
+        <input class="action-button" type="submit" value="create" />
       </form>
     </div>
   </div>
 </template>
 
 <script>
-import { saveDashboard } from '../lib/configuration.js';
-import templates from '../lib/templates.js';
-import createGuid from '../lib/guid.js';
+import { saveDashboard } from "../lib/configuration.js";
+import templates from "../lib/templates.js";
+import createGuid from "../lib/guid.js";
 
 export default {
-  name: 'dashboard-settings',
-  props: ['dashboard'],
+  name: "dashboard-settings",
+  props: ["dashboard"],
   data: function() {
     return {
-      status: '',
+      status: "",
       settingsPanelOpen: true
     };
   },
@@ -63,15 +85,15 @@ export default {
         eventData[name] = value;
       });
 
-      this.$emit('save-settings', eventData);
+      this.$emit("save-settings", eventData);
     },
     onCreateCard: function(event) {
       const formData = new FormData(event.target);
       const id = createGuid();
-      const tileTemplate = templates[formData.get('type')];
+      const tileTemplate = templates[formData.get("type")];
       const newTile = Object.assign({}, tileTemplate, { id });
 
-      this.$emit('tile-create', newTile);
+      this.$emit("tile-create", newTile);
     },
     onToggleSettingsPanel() {
       this.settingsPanelOpen = this.settingsPanelOpen === true ? false : true;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,7 +1,10 @@
-import Vue from 'vue';
-import App from './components/App';
+import Vue from "vue";
+import App from "./components/App";
+import VueA11yDialog from "vue-a11y-dialog";
+
+Vue.use(VueA11yDialog);
 
 const vm = new Vue({
-  el: '#app',
+  el: "#app",
   render: h => h(App)
 });


### PR DESCRIPTION
This pull request implements the change requested in #21. Note: This task was already claimed by a user in April of 2018, but I don’t believe they’re currently working on this.

---

Using [vue-a11y-dialog](https://github.com/morkro/vue-a11y-dialog), the alert-style confirmation to remove a card was replaced with a modal. While applying this change, I did a bit of clean-up regarding various button styles.

Also, there are quite a lot of changes originating from `pretty-quick` running upon committing changes. In hindsight, I should’ve the formatting changes in a separate commit. If I find the time, I’m submitting a pull request after this one in which I apply the `pretty-quick` formatting to all files so future contributors don’t have to worry about it.

Have a lovely day. :sun_with_face: 