### PR TITLE
Add color picker to dashboard settings (an initial concept)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3577,6 +3577,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "clamp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
+      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -8172,6 +8177,11 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -8265,6 +8275,11 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.0.tgz",
       "integrity": "sha512-HduzIW2xApSXKXJSpCipSxKyvMbwRRa/TwMbepmlZziKdH8548WSoDP4SxzulEKjlo8BE39l+2fwJZuRKOln6g=="
+    },
+    "material-colors": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -10151,9 +10166,9 @@
       "dev": true
     },
     "portal-vue": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-1.5.1.tgz",
-      "integrity": "sha512-7T0K+qyY8bnjnEpQTiLbGsUaGlFcemK9gLurVSr6x1/qzr2HkHDNCOz5i+xhuTD1CrXckf/AGeCnLzvmAHMOHw=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.4.tgz",
+      "integrity": "sha512-Mr2h+RvoOOGHS7N0E3QPP+UQMt1OhSjQ7eMSGTXqkLiO0AjGEDw2x4kzmHATsZfDqQumiaYSDRzlUP2By3lvsA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -12104,6 +12119,11 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tinycolor2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -12707,17 +12727,28 @@
       }
     },
     "vue": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.3.tgz",
-      "integrity": "sha512-yftjtahz4UTAtOlXXuw7UaYD86fWrMDAAzqTdqJJx2FIBqcPmBN6kPBHiBJFGaQELVblb5ijbFMXsx0i0F7q3g=="
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
+      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
     },
     "vue-a11y-dialog": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/vue-a11y-dialog/-/vue-a11y-dialog-0.4.2.tgz",
-      "integrity": "sha512-GFXVKmbR5XkZ2+ZnEAJJzOMH6kC0V4/2WSlnA97FL6se3/AA0uCc17Xkb3bBu0iG3WpC4R98dG+UWHj7WiuJNQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/vue-a11y-dialog/-/vue-a11y-dialog-0.5.0.tgz",
+      "integrity": "sha512-qGrcSRz8yZGqASkJ+xJozQUO11Sxhap4AkzMPHuTNyFsFQb2HC8Gg7OXLMjsUTQGSihS1AZEIFsL2cZaHvmTeA==",
       "requires": {
         "a11y-dialog": "^5.2.0",
-        "portal-vue": "^1.5.1"
+        "portal-vue": "^2.1.0"
+      }
+    },
+    "vue-color": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/vue-color/-/vue-color-2.7.0.tgz",
+      "integrity": "sha512-fak9oPRL3BsYtakTGmWIS2yNRppRYNlMgGGq78CMH34ipU8fLgi/bT9JiSPcscpdTNLGracuOFuZ8OFeml+SQQ==",
+      "requires": {
+        "clamp": "^1.0.1",
+        "lodash.throttle": "^4.0.0",
+        "material-colors": "^1.0.0",
+        "tinycolor2": "^1.1.2"
       }
     },
     "vue-focus": {
@@ -12729,9 +12760,9 @@
       }
     },
     "vue-hot-reload-api": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.1.tgz",
-      "integrity": "sha512-AA86yKZ5uOKz87/q1UpngEXhbRkaYg1b7HMMVRobNV1IVKqZe8oLIzo6iMocVwZXnYitlGwf2k4ZRLOZlS8oPQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.3.tgz",
+      "integrity": "sha512-KmvZVtmM26BQOMK1rwUZsrqxEGeKiYSZGA7SNWE6uExx8UX/cj9hq2MRV/wWC3Cq6AoeDGk57rL9YMFRel/q+g==",
       "dev": true
     },
     "vue-jest": {
@@ -12780,9 +12811,9 @@
       }
     },
     "vue-loader": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.6.2.tgz",
-      "integrity": "sha512-T6fONodj861M3PqZ1jlbUFjeezbUnPRY2bd+3eZuDvYADgkN3VFU2H5feqySNg9XBt8rcbyBGmFWTZtrOX+v5w==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.7.0.tgz",
+      "integrity": "sha512-x+NZ4RIthQOxcFclEcs8sXGEWqnZHodL2J9Vq+hUz+TDZzBaDIh1j3d9M2IUlTjtrHTZy4uMuRdTi8BGws7jLA==",
       "dev": true,
       "requires": {
         "@vue/component-compiler-utils": "^2.5.1",
@@ -12803,9 +12834,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.3.tgz",
-      "integrity": "sha512-SQ3lJk7fwquz8fGac7MwvP9cEBZntokTWITaDrLC0zmyBKjcOfJtWZkMsv+2uSUBDD8kwz8Bsad9xmBWaNULhg==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
+      "integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "express-sanitizer": "^1.0.5",
     "marked": "0.6.0",
     "socket.io": "2.2.0",
-    "vue": "2.6.3",
-    "vue-a11y-dialog": "^0.4.2",
-    "vue-focus": "2.1.0"
+    "vue": "^2.6.10",
+    "vue-a11y-dialog": "^0.5.0",
+    "vue-color": "^2.7.0",
+    "vue-focus": "^2.1.0"
   },
   "engines": {
     "node": ">= 10"
@@ -62,8 +63,8 @@
     "pretty-quick": "^1.10.0",
     "puppeteer": "^1.12.2",
     "vue-jest": "^4.0.0-beta.2",
-    "vue-loader": "^15.6.2",
-    "vue-template-compiler": "^2.6.3",
+    "vue-loader": "^15.7.0",
+    "vue-template-compiler": "^2.6.10",
     "webpack": "^4.29.3",
     "webpack-cli": "^3.2.3",
     "webpack-watch-server": "^1.2.1"

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -454,3 +454,9 @@ dialog[open] {
 .dialog-container[aria-hidden="true"] {
   display: none;
 }
+
+.vc-compact {
+  margin-bottom: 10px;
+  box-sizing: content-box;
+  box-shadow: none;
+}

--- a/public/js/components/DashboardSettings.vue
+++ b/public/js/components/DashboardSettings.vue
@@ -15,9 +15,9 @@
             settingsPanelOpen ? "Close settings panel" : "Open settings panel"
           }}
         </span>
-        <span aria-hidden="true">
-          {{ settingsPanelOpen ? "&rarr;" : "⚙️" }}
-        </span>
+        <span aria-hidden="true">{{
+          settingsPanelOpen ? "&rarr;" : "⚙️"
+        }}</span>
       </button>
 
       <h2 class="settings__title">Settings</h2>
@@ -32,7 +32,8 @@
 
         <label>
           Background Color
-          <input type="text" name="bgColor" v-bind:value="dashboard.bgColor" />
+          <compact-picker :value="bgColor" @input="updateValue" />
+          <input type="text" name="bgColor" :value="bgColor" />
         </label>
 
         <label>
@@ -75,6 +76,7 @@
 </template>
 
 <script>
+import { Compact } from "vue-color";
 import { saveDashboard } from "../lib/configuration.js";
 import templates from "../lib/templates.js";
 import createGuid from "../lib/guid.js";
@@ -82,11 +84,15 @@ import createGuid from "../lib/guid.js";
 export default {
   name: "dashboard-settings",
   props: ["dashboard"],
-  data: function() {
+  data() {
     return {
       status: "",
-      settingsPanelOpen: true
+      settingsPanelOpen: true,
+      bgColor: this.dashboard.bgColor
     };
+  },
+  components: {
+    "compact-picker": Compact
   },
   methods: {
     onSaveSettings: function(event) {
@@ -108,6 +114,9 @@ export default {
     },
     onToggleSettingsPanel() {
       this.settingsPanelOpen = this.settingsPanelOpen === true ? false : true;
+    },
+    updateValue(value) {
+      this.bgColor = value.hex;
     }
   }
 };

--- a/public/js/components/DashboardSettings.vue
+++ b/public/js/components/DashboardSettings.vue
@@ -15,9 +15,9 @@
             settingsPanelOpen ? "Close settings panel" : "Open settings panel"
           }}
         </span>
-        <span aria-hidden="true">{{
-          settingsPanelOpen ? "&rarr;" : "⚙️"
-        }}</span>
+        <span aria-hidden="true">
+          {{ settingsPanelOpen ? "&rarr;" : "⚙️" }}
+        </span>
       </button>
 
       <h2 class="settings__title">Settings</h2>
@@ -33,7 +33,7 @@
         <label>
           Background Color
           <compact-picker :value="bgColor" @input="updateValue" />
-          <input type="text" name="bgColor" :value="bgColor" />
+          <input type="text" name="bgColor" v-model="bgColor" />
         </label>
 
         <label>


### PR DESCRIPTION
This pull request is a stepping stone towards #9 and adds a color picker to the dashboard settings field for the background color. It uses [vue-color](http://xiaokaike.github.io/vue-color).

Right off the bat, this implementation has severe shortcomings in terms of accessibility. Vue-color comes with a variety of picker styles, all of which only have the most basic keyboard accessibility (e.g. entering color names or values into a text input). For some of this components, one could implement more sophisticated versions; for example, navigating the compact color picker with arrow keys since it is laid out as a grid.

That said, this pull request is meant as an initial concept; hence, it only implements a color picker at one place in the UI, the dashboard settings. If it looks right, we can consider whether we want to continue integrating it, whether we want to use a different picker style, etc. I might be able to contribute more accessible components upstream, but I’d like to know first if the direction is good.

Ah, right. I also updated all Vue dependencies. Doing another round of dependency updates during the week after the active pull requests are merged. :)

See you in, well, actually less than half an hour! 🎇