### PR TITLE
bump contrast of button color above WCAG AA 4.5 requirement

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -173,7 +173,7 @@ button::-moz-focus-inner {
 .action-button {
   font-family: "Chivo", sans-serif;
   border: none;
-  background-color: #5786c1;
+  background-color: hsl(214, 45%, 47%);
   color: white;
   padding: 8px 14px;
   font-weight: normal;
@@ -185,15 +185,20 @@ button::-moz-focus-inner {
   cursor: pointer;
   /* needed for anchors */
   position: relative;
-  box-shadow: 1px 0 #3a587f, 0 1px #4171ae, 2px 1px #3a587f, 1px 2px #4171ae,
-    3px 2px #3a587f, 2px 3px #4171ae, 4px 3px #3a587f, 3px 4px #4171ae,
-    5px 4px #3a587f, 4px 5px #4171ae, 6px 5px #3a587f, 5px 6px #4171ae;
+  box-shadow: 1px 0 hsla(214, 45%, 30%, 1), 0 1px hsla(214, 45%, 40%, 1),
+    2px 1px hsla(214, 45%, 30%, 1), 1px 2px hsla(214, 45%, 40%, 1),
+    3px 2px hsla(214, 45%, 30%, 1), 2px 3px hsla(214, 45%, 40%, 1),
+    4px 3px hsla(214, 45%, 30%, 1), 3px 4px hsla(214, 45%, 40%, 1),
+    5px 4px hsla(214, 45%, 30%, 1), 4px 5px hsla(214, 45%, 40%, 1),
+    6px 5px hsla(214, 45%, 30%, 1), 5px 6px hsla(214, 45%, 40%, 1);
 }
 
 .action-button:hover {
   transform: translate(2px, 2px);
-  box-shadow: 1px 0 #3a587f, 0 1px #4171ae, 2px 1px #3a587f, 1px 2px #4171ae,
-    3px 2px #3a587f, 2px 3px #4171ae, 4px 3px #3a587f, 3px 4px #4171ae;
+  box-shadow: 1px 0 hsla(214, 45%, 30%, 1), 0 1px hsla(214, 45%, 40%, 1),
+    2px 1px hsla(214, 45%, 30%, 1), 1px 2px hsla(214, 45%, 40%, 1),
+    3px 2px hsla(214, 45%, 30%, 1), 2px 3px hsla(214, 45%, 40%, 1),
+    4px 3px hsla(214, 45%, 30%, 1), 3px 4px hsla(214, 45%, 40%, 1);
 }
 
 .action-button:focus {


### PR DESCRIPTION
Fixes #27 !

Here is the before and after, respectively:

![Screen Shot 2019-05-19 at 10 47 11 AM](https://user-images.githubusercontent.com/1411284/57985942-baec4080-7a23-11e9-95ca-c8e797abf1a9.png)
![Screen Shot 2019-05-19 at 10 45 29 AM](https://user-images.githubusercontent.com/1411284/57985951-bfb0f480-7a23-11e9-9d3d-b3bc09c8952a.png)
