### PR TITLE
Move cards with keyboard

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -502,3 +502,13 @@ dialog[open] {
   box-sizing: content-box;
   box-shadow: none;
 }
+
+/**
+ * Stops content from being selected (e.g. when moving around cards).
+ */
+body.dragging {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -8,6 +8,12 @@
   box-sizing: border-box;
 }
 
+:root {
+  --focus-color: hotpink;
+  --focus-outline: 2px solid var(--focus-color);
+  --focus-box-shadow: 0 0 0 2px var(--focus-color);
+}
+
 html,
 body {
   width: 100%;
@@ -18,6 +24,9 @@ body {
   position: relative;
   font-family: helvetica, arial, sans-serif;
 }
+
+:focus {
+  outline: var(--focus-outline);
 }
 
 .bold {
@@ -76,6 +85,11 @@ footer > a {
   border-radius: 6px;
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
   background-color: white;
+}
+
+.card:focus {
+  outline: none;
+  box-shadow: var(--focus-box-shadow);
 }
 
 .card:not(:last-child) {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -8,11 +8,16 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  width: 100%;
+  height: 100%;
+}
+
 body {
   position: relative;
   font-family: helvetica, arial, sans-serif;
-  width: 100%;
-  height: 100%;
+}
 }
 
 .bold {
@@ -99,7 +104,7 @@ h1 {
   color: black;
   font-family: "Nanum Pen Script", sans-serif;
   font-size: 50px;
-  margin-top: 0px;
+  margin-top: 0;
 }
 
 h1 .hemoji {
@@ -107,16 +112,16 @@ h1 .hemoji {
 }
 
 #dashboard {
-  margin: 0px;
+  margin: 0;
   padding: 25px;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   overflow: auto;
 }
 
 .card h2 {
-  padding: 0px;
-  margin: 0px 0px 15px 0px;
+  padding: 0;
+  margin: 0 0 15px 0;
   font-size: 20px;
   font-family: "Chivo", sans-serif;
   word-wrap: break-word;
@@ -131,8 +136,8 @@ h1 .hemoji {
   font-size: 64px;
   font-weight: bold;
   text-align: center;
-  padding: 0px;
-  margin: 0px;
+  padding: 0;
+  margin: 0;
   font-family: "Chivo", sans-serif;
 }
 
@@ -302,7 +307,7 @@ select {
 
 .settings {
   min-width: 280px;
-  right: 0px;
+  right: 0;
   top: 50px;
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -80,16 +80,33 @@ footer > a {
 }
 
 .card {
+  --card-border-radius: 6px;
+  --card-border-width: 2px;
+
+  position: relative;
   padding: 15px;
-  border: 2px solid #222;
-  border-radius: 6px;
+  border: var(--card-border-width) solid #222;
+  border-radius: var(--card-border-radius);
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
   background-color: white;
 }
 
 .card:focus {
   outline: none;
-  box-shadow: var(--focus-box-shadow);
+}
+
+.card:focus::before {
+  --focus-offset: calc(-2 * var(--card-border-width));
+
+  content: "";
+  position: absolute;
+  top: var(--focus-offset);
+  left: var(--focus-offset);
+  right: var(--focus-offset);
+  bottom: var(--focus-offset);
+  border: var(--card-border-width) dotted var(--background-color);
+  border-radius: var(--card-border-radius);
+  filter: invert(100%);
 }
 
 .card:not(:last-child) {
@@ -131,6 +148,7 @@ h1 .hemoji {
   width: 100%;
   height: 100%;
   overflow: auto;
+  background-color: var(--background-color);
 }
 
 .card h2 {

--- a/public/js/components/App.vue
+++ b/public/js/components/App.vue
@@ -66,7 +66,7 @@ export default {
         var bgImageRepeatBool = JSON.parse(this.dashboard.bgImageRepeat);
       }
       return {
-        backgroundColor: this.dashboard.bgColor,
+        "--background-color": this.dashboard.bgColor,
         backgroundImage: this.dashboard.bgImageUrl
           ? `url(${this.dashboard.bgImageUrl})`
           : "",

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -1,16 +1,16 @@
 <template>
   <div
     class="card"
-    v-bind:class="{ dragging: dragging }"
-    v-bind:style="style"
-    v-on:mousedown.stop="onMouseDown"
+    :class="{ dragging: draggingWithMouse }"
+    :style="style"
+    @mousedown.stop="onMouseDown"
   >
     <div v-if="showChildCard">
       <div v-if="showControls" class="controls">
         <button
           class="inline-button edit-button"
           ref="editButton"
-          v-on:click="onEdit"
+          @click="onEdit"
         >
           edit
         </button>
@@ -27,23 +27,21 @@
       <h2 v-if="tile.title">{{ tile.title }}</h2>
 
       <component
-        v-bind:is="childCard"
-        v-bind:tile="tile"
-        v-bind:blockSize="blockSize"
-        v-bind:messages="messages"
-      >
-      </component>
+        :is="childCard"
+        :tile="tile"
+        :blockSize="blockSize"
+        :messages="messages"
+      ></component>
     </div>
 
     <card-form
       v-if="showForm"
-      v-bind:editing="editing"
-      v-bind:tile="tile"
-      v-bind:deviceList="deviceList"
-      v-bind:cardType="childCard"
-      v-on:save-settings="onSaveSettings"
-    >
-    </card-form>
+      :editing="editing"
+      :tile="tile"
+      :deviceList="deviceList"
+      :cardType="childCard"
+      @save-settings="onSaveSettings"
+    ></card-form>
 
     <a11y-dialog
       id="app-dialog"
@@ -99,10 +97,11 @@ export default {
     StickerCard,
     TextCard
   },
+
   data() {
     return {
       editing: false,
-      dragging: false,
+      draggingWithMouse: false,
       mouseMoved: false,
       y: this.tile.position[1],
       x: this.tile.position[0],
@@ -111,53 +110,60 @@ export default {
       dialog: null
     };
   },
+
   methods: {
     assignDialogRef(dialog) {
       this.dialog = dialog;
     },
 
-    onMouseDown: function(event) {
+    onMouseDown(event) {
       const allowedModes = ["unlocked", "demo"];
       const excludedNodes = ["INPUT", "TEXTAREA", "SELECT", "LABEL"];
       if (
-        !this.dragging &&
+        !this.draggingWithMouse &&
         !excludedNodes.includes(event.target.tagName) &&
         allowedModes.includes(this.editMode)
       ) {
-        this.dragging = true;
+        this.draggingWithMouse = true;
         this.offsetY = event.clientY - this.y;
         this.offsetX = event.clientX - this.x;
         window.addEventListener("mousemove", this.onMouseMove, true);
       }
     },
-    onMouseMove: function(event) {
+
+    onMouseMove(event) {
       this.mouseMoved = true;
       this.y = event.clientY - this.offsetY;
       this.x = event.clientX - this.offsetX;
     },
-    onMouseUp: function(event) {
+
+    onMouseUp(event) {
       window.removeEventListener("mousemove", this.onMouseMove, true);
-      if (this.dragging && this.mouseMoved) {
+      if (this.draggingWithMouse && this.mouseMoved) {
         const newPosition = { position: [this.x, this.y] };
         const eventData = Object.assign({}, this.tile, newPosition);
 
         this.$emit("tile-position", eventData);
       }
-      this.dragging = false;
+      this.draggingWithMouse = false;
       this.mouseMoved = false;
     },
-    onEdit: function() {
+
+    onEdit() {
       this.editing = true;
     },
+
     openCardDeleteModal() {
       if (this.dialog) {
         this.dialog.show();
       }
     },
+
     deleteTile(tileId) {
       this.$emit("tile-delete", tileId);
     },
-    onSaveSettings: function(event) {
+
+    onSaveSettings(event) {
       this.editing = false;
       // focus on edit button
       this.$nextTick(function() {
@@ -166,14 +172,17 @@ export default {
       this.$emit("tile-settings", event);
     }
   },
+
   computed: {
-    top: function() {
+    top() {
       return `${this.y}px`;
     },
-    left: function() {
+
+    left() {
       return `${this.x}px`;
     },
-    style: function() {
+
+    style() {
       return {
         top: this.top,
         left: this.left,
@@ -181,20 +190,25 @@ export default {
         minHeight: `${this.blockSize[1] * this.tile.size[1]}px`
       };
     },
-    childCard: function() {
+
+    childCard() {
       return `${this.tile.type.toLowerCase()}-card`;
     },
-    showChildCard: function() {
+
+    showChildCard() {
       return !this.editing;
     },
-    showForm: function() {
+
+    showForm() {
       return this.editing;
     },
-    showControls: function() {
+
+    showControls() {
       const allowedModes = ["unlocked", "demo"];
       return allowedModes.includes(this.editMode);
     }
   },
+
   mounted() {
     window.addEventListener("mouseup", this.onMouseUp, false);
   }

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -113,6 +113,16 @@ export default {
     };
   },
 
+  watch: {
+    draggingWithMouse: function(dragging) {
+      if (dragging) {
+        document.body.classList.add("dragging");
+      } else if (document.body.classList.contains("dragging")) {
+        document.body.classList.remove("dragging");
+      }
+    }
+  },
+
   methods: {
     assignDialogRef(dialog) {
       this.dialog = dialog;

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -1,9 +1,11 @@
 <template>
   <div
     class="card"
+    tabindex="0"
     :class="{ dragging: draggingWithMouse }"
     :style="style"
     @mousedown.stop="onMouseDown"
+    @keydown="moveCard"
   >
     <div v-if="showChildCard">
       <div v-if="showControls" class="controls">
@@ -170,6 +172,25 @@ export default {
         this.$refs.editButton.focus();
       });
       this.$emit("tile-settings", event);
+    },
+
+    moveCard(event) {
+      // We should bail out early if
+      // - the card doesn’t have focus
+      // - the pressed key is not an arrow key
+      if (
+        document.activeElement !== this.$el ||
+        !["ArrowUp", "ArrowRight", "ArrowDown", "ArrowLeft"].includes(event.key)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const direction = ["ArrowLeft", "ArrowUp"].includes(event.key) ? -1 : 1;
+      const axis = ["ArrowLeft", "ArrowRight"].includes(event.key) ? "x" : "y";
+      const step = event.shiftKey ? 10 : 1;
+      this[axis] += direction * step;
     }
   },
 

--- a/public/js/components/specs/App.spec.js
+++ b/public/js/components/specs/App.spec.js
@@ -68,7 +68,7 @@ describe("Number card", () => {
     vm.dashboard.bgImageRepeat = mockDashboardData.dashboard.bgImageRepeat;
 
     expect(vm.dashStyle).toEqual({
-      backgroundColor: vm.dashboard.bgColor,
+      "--background-color": vm.dashboard.bgColor,
       backgroundImage: vm.dashboard.bgImageUrl,
       backgroundRepeat: "repeat"
     });
@@ -76,7 +76,7 @@ describe("Number card", () => {
     vm.dashboard.bgImageRepeat = false;
 
     expect(vm.dashStyle).toEqual({
-      backgroundColor: vm.dashboard.bgColor,
+      "--background-color": vm.dashboard.bgColor,
       backgroundImage: vm.dashboard.bgImageUrl,
       backgroundRepeat: "no-repeat"
     });

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -4,7 +4,8 @@ import VueA11yDialog from "vue-a11y-dialog";
 
 Vue.use(VueA11yDialog);
 
-const vm = new Vue({
+new Vue({
   el: "#app",
+
   render: h => h(App)
 });


### PR DESCRIPTION
This pull request adds keyboard navigation to cards (implements #4). It behaves like this:

- Cards can now be focused (i.e. they have `tabindex="0"`).
- If a card is focused *and* an arrow key is pressed, the card’s position will be updated in steps of 1 pixel (10 pixels if the `Shift` key is pressed) per keypress.

Additionally, I added a basic focus style to all elements and one to the cards in particular. This also improves focus styles for some unrelated elements (e.g. settings panel toggle, settings text inputs).

If I find the time this week, I will add the following things to this pull request:

- Prevent selecting text when dragging a card.
- Prevent cards from being dragged/moved off-screen.

**Note on accessibility**:

In order to make use of this feature, a user has to know about it. Currently, a user has no way of knowing what kind of interaction is possible when a card has focus. I’m not aware of an interactive element or accessible role that would convey “Hey, this element can be moved with arrow keys”. Therefore, there should be some kind of instruction explaining the possible interactions. I’m unsure how to go about this.