### PR TITLE
Refine card movement behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7616,7 +7616,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -7921,6 +7922,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0"
       }
@@ -11624,14 +11626,6 @@
         "lodash.throttle": "^4.0.0",
         "material-colors": "^1.0.0",
         "tinycolor2": "^1.1.2"
-      }
-    },
-    "vue-focus": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vue-focus/-/vue-focus-2.1.0.tgz",
-      "integrity": "sha1-egM3zpB01e8D0VpLW4Ys9F5eBOM=",
-      "requires": {
-        "loose-envify": "^1.2.0"
       }
     },
     "vue-hot-reload-api": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "vue": "^2.6.10",
     "vue-a11y-dialog": "^0.5.0",
     "vue-color": "^2.7.0",
-    "vue-focus": "^2.1.0",
     "whatwg-fetch": "^3.0.0"
   },
   "engines": {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -107,6 +107,7 @@ footer > a {
   border: var(--card-border-width) dotted var(--background-color);
   border-radius: var(--card-border-radius);
   filter: invert(100%);
+  pointer-events: none;
 }
 
 .card:not(:last-child) {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -94,6 +94,15 @@ footer > a {
   background-color: white;
 }
 
+.card--is-being-dragged:hover {
+  cursor: move;
+  user-select: none;
+}
+
+.card:not(.card--is-being-edited) {
+  cursor: grab;
+}
+
 .card:focus {
   outline: none;
 }
@@ -260,11 +269,6 @@ input[type="submit"]::-moz-focus-inner {
 .action-button:active {
   transform: translate(4px, 4px);
   box-shadow: none;
-}
-
-.card.dragging:hover {
-  cursor: move;
-  user-select: none;
 }
 
 .card form input[type="submit"] {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -195,7 +195,12 @@ button {
   font: inherit;
 }
 
+/*
+Remove very strange and unnecessary focus outline in Firefox.
+Firefox, why are you like this?
+*/
 button::-moz-focus-inner,
+input[type="button"]::-moz-focus-inner,
 input[type="submit"]::-moz-focus-inner {
   padding: 0;
   border-style: none;
@@ -231,18 +236,23 @@ input[type="submit"]::-moz-focus-inner {
 }
 
 .action-button {
-  --base-box-shadow: 1px 0 hsla(214, 45%, 30%, 1), 0 1px hsla(214, 45%, 40%, 1),
-    2px 1px hsla(214, 45%, 30%, 1), 1px 2px hsla(214, 45%, 40%, 1),
-    3px 2px hsla(214, 45%, 30%, 1), 2px 3px hsla(214, 45%, 40%, 1),
-    4px 3px hsla(214, 45%, 30%, 1), 3px 4px hsla(214, 45%, 40%, 1);
+  --c-button-bg: hsl(214, 45%, 47%);
+  --c-button-bg-dark-1: hsl(214, 45%, 40%);
+  --c-button-bg-dark-2: hsl(214, 45%, 30%);
 
-  --ext-box-shadow: var(--base-box-shadow), 5px 4px hsla(214, 45%, 30%, 1),
-    4px 5px hsla(214, 45%, 40%, 1), 6px 5px hsla(214, 45%, 30%, 1),
-    5px 6px hsla(214, 45%, 40%, 1);
+  --base-box-shadow: 1px 0 var(--c-button-bg-dark-2),
+    0 1px var(--c-button-bg-dark-1), 2px 1px var(--c-button-bg-dark-2),
+    1px 2px var(--c-button-bg-dark-1), 3px 2px var(--c-button-bg-dark-2),
+    2px 3px var(--c-button-bg-dark-1), 4px 3px var(--c-button-bg-dark-2),
+    3px 4px var(--c-button-bg-dark-1);
+
+  --ext-box-shadow: var(--base-box-shadow), 5px 4px var(--c-button-bg-dark-2),
+    4px 5px var(--c-button-bg-dark-1), 6px 5px var(--c-button-bg-dark-2),
+    5px 6px var(--c-button-bg-dark-1);
 
   font-family: "Chivo", sans-serif;
   border: none;
-  background-color: hsl(214, 45%, 47%);
+  background-color: var(--c-button-bg);
   color: white;
   padding: 8px 14px;
   font-weight: normal;
@@ -255,6 +265,13 @@ input[type="submit"]::-moz-focus-inner {
   /* needed for anchors */
   position: relative;
   box-shadow: var(--ext-box-shadow);
+  width: calc(100% - 6px);
+}
+
+.action-button--secondary {
+  --c-button-bg: hsl(214, 0%, 47%);
+  --c-button-bg-dark-1: hsl(214, 0%, 40%);
+  --c-button-bg-dark-2: hsl(214, 0%, 30%);
 }
 
 .action-button:hover {
@@ -269,12 +286,6 @@ input[type="submit"]::-moz-focus-inner {
 .action-button:active {
   transform: translate(4px, 4px);
   box-shadow: none;
-}
-
-.card form input[type="submit"] {
-  padding: 5px;
-  font-size: 14px;
-  width: 97%;
 }
 
 .card .controls {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -23,6 +23,9 @@ body {
 body {
   position: relative;
   font-family: helvetica, arial, sans-serif;
+  background-color: var(--background-color);
+  background-image: var(--background-image);
+  background-repeat: var(--background-repeat);
 }
 
 :focus {
@@ -149,7 +152,6 @@ h1 .hemoji {
   width: 100%;
   height: 100%;
   overflow: auto;
-  background-color: var(--background-color);
 }
 
 .card h2 {

--- a/public/js/components/App.vue
+++ b/public/js/components/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="dashboard" :style="dashStyle">
+  <div id="dashboard">
     <header>
       <h1 v-bind:style="headingStyle" v-html="appTitle"></h1>
       <div v-if="simulating" :style="headingStyle" class="simulation-status">
@@ -58,21 +58,20 @@ export default {
   name: "main-app",
   components: { BaseCard, DashboardSettings },
   data: initialData,
-  computed: {
-    dashStyle: function() {
-      // saveSettings() uses FormData, which converts booleans to strings, so
-      // there's a chance we might get a string. Let's convert it back!
-      if (typeof this.dashboard.bgImageRepeat !== "undefined") {
-        var bgImageRepeatBool = JSON.parse(this.dashboard.bgImageRepeat);
-      }
-      return {
-        "--background-color": this.dashboard.bgColor,
-        backgroundImage: this.dashboard.bgImageUrl
-          ? `url(${this.dashboard.bgImageUrl})`
-          : "",
-        backgroundRepeat: bgImageRepeatBool === true ? "repeat" : "no-repeat"
-      };
+  watch: {
+    "dashboard.bgColor": function(bgColor) {
+      document.body.style.setProperty("--background-color", bgColor);
     },
+    "dashboard.bgImageUrl": function(bgImageUrl) {
+      const bgImage = bgImageUrl !== "" ? `url(${bgImageUrl})` : "";
+      document.body.style.setProperty("--background-image", bgImage);
+    },
+    "dashboard.bgImageRepeat": function(bgImageRepeat) {
+      const bgRepeat = Boolean(bgImageRepeat) ? "repeat" : "no-repeat";
+      document.body.style.setProperty("--background-repeat", bgRepeat);
+    }
+  },
+  computed: {
     headingStyle: function() {
       const color = contrastColor(this.dashboard.bgColor, "#fff", "#000");
       return { color };

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -2,7 +2,10 @@
   <div
     class="card"
     tabindex="0"
-    :class="{ dragging: draggingCard }"
+    :class="{
+      'card--is-being-dragged': draggingCard,
+      'card--is-being-edited': editingCard
+    }"
     :style="style"
     @mousedown.stop.passive="startDraggingCardWithMouse"
     @touchstart.stop.passive="startDraggingCardWithTouch"

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -282,7 +282,6 @@ export default {
       const newCardPosition = {};
       newCardPosition[axis] = this[axis] + direction * step;
       this.updateCardPosition(newCardPosition);
-      this.emitCardPosition();
     },
 
     /**
@@ -333,6 +332,16 @@ export default {
   },
 
   mounted() {
+    // Before a window unloads its resources (e.g. when reloading or closing the tab),
+    // we try to emit the card’s position so it is properly stored.
+    window.addEventListener(
+      "beforeunload",
+      () => {
+        this.emitCardPosition();
+      },
+      { passive: true }
+    );
+
     // It’s necessary that this event handler is registered on the window rather than the card
     // itself. If it’s registered on the card, a fast movement of the mouse can escape the card
     // quicker than what causes to the card to be re-rendered at the new position. This leads to

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -267,6 +267,7 @@ export default {
      */
     moveCardWithArrows(event) {
       if (
+        this.editingCard ||
         document.activeElement !== this.$el ||
         !["ArrowUp", "ArrowRight", "ArrowDown", "ArrowLeft"].includes(event.key)
       ) {
@@ -282,6 +283,7 @@ export default {
       const newCardPosition = {};
       newCardPosition[axis] = this[axis] + direction * step;
       this.updateCardPosition(newCardPosition);
+      this.emitCardPosition();
     },
 
     /**
@@ -332,16 +334,6 @@ export default {
   },
 
   mounted() {
-    // Before a window unloads its resources (e.g. when reloading or closing the tab),
-    // we try to emit the card’s position so it is properly stored.
-    window.addEventListener(
-      "beforeunload",
-      () => {
-        this.emitCardPosition();
-      },
-      { passive: true }
-    );
-
     // It’s necessary that this event handler is registered on the window rather than the card
     // itself. If it’s registered on the card, a fast movement of the mouse can escape the card
     // quicker than what causes to the card to be re-rendered at the new position. This leads to

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -4,7 +4,7 @@
     tabindex="0"
     :class="{ dragging: draggingCard }"
     :style="style"
-    @mousedown.stop.capture="startDraggingCard"
+    @mousedown.stop="startDraggingCard"
     @keydown="moveCardWithArrows"
   >
     <div v-if="showChildCard">
@@ -104,7 +104,7 @@ export default {
     return {
       editing: false,
       draggingCard: false,
-      mouseWasMovedWhileDragging: false,
+      cardHasBeenMoved: false,
 
       // The position of a card’s top-left corner relative to the dashboard
       x: this.tile.position[0],
@@ -139,6 +139,7 @@ export default {
 
       if (
         event.buttons !== 1 || // primary mouse button
+        this.editingCard ||
         excludedNodes.includes(event.target.tagName) ||
         !allowedModes.includes(this.editMode)
       ) {
@@ -153,11 +154,11 @@ export default {
     dragCard(event) {
       event.stopPropagation();
 
-      if (!this.draggingCard) {
+      if (!this.draggingCard || this.editingCard) {
         return;
       }
 
-      this.mouseWasMovedWhileDragging = true;
+      this.cardHasBeenMoved = true;
 
       this.updateCardPosition({
         x: event.clientX - this.offsetX,
@@ -166,18 +167,11 @@ export default {
     },
 
     stopDraggingCard(event) {
-      if (!this.draggingCard || !this.mouseWasMovedWhileDragging) {
-        return;
-      }
-
       this.draggingCard = false;
-      this.mouseWasMovedWhileDragging = false;
 
+      if (this.cardHasBeenMoved) {
       this.emitCardPosition();
-    },
-
-    onEdit() {
-      this.editing = true;
+      }
     },
 
     openCardDeleteModal() {

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -173,10 +173,7 @@ export default {
       this.draggingCard = false;
       this.mouseWasMovedWhileDragging = false;
 
-      const newPosition = { position: [this.x, this.y] };
-      const eventData = Object.assign({}, this.tile, newPosition);
-
-      this.$emit("tile-position", eventData);
+      this.emitCardPosition();
     },
 
     onEdit() {
@@ -229,6 +226,7 @@ export default {
       const newCardPosition = {};
       newCardPosition[axis] = this[axis] + direction * step;
       this.updateCardPosition(newCardPosition);
+      this.emitCardPosition();
     },
 
     /**
@@ -240,6 +238,13 @@ export default {
     updateCardPosition({ x = this.x, y = this.y }) {
       this.x = Math.max(0, x);
       this.y = Math.max(0, y);
+    },
+
+    emitCardPosition() {
+      const newPosition = { position: [this.x, this.y] };
+      const eventData = Object.assign({}, this.tile, newPosition);
+
+      this.$emit("tile-position", eventData);
     }
   },
 

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -209,10 +209,12 @@ export default {
      */
     onSaveSettings(eventData) {
       this.editingCard = false;
-      // focus on edit button
+
+      // Return focus to the edit button
       this.$nextTick(function() {
         this.$refs.editButton.focus();
       });
+
       this.$emit("tile-settings", eventData);
     },
 

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -47,6 +47,7 @@
       :deviceList="deviceList"
       :cardType="childCard"
       @save-settings="onSaveSettings"
+      @cancel-editing="editingCard = false"
     ></card-form>
 
     <a11y-dialog

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -220,10 +220,7 @@ export default {
       });
     },
 
-    /**
-     * @param {MouseEvent} event
-     */
-    stopDraggingCard(event) {
+    stopDraggingCard() {
       this.draggingCard = false;
 
       if (this.cardHasBeenMoved) {

--- a/public/js/components/CardForm.vue
+++ b/public/js/components/CardForm.vue
@@ -18,6 +18,13 @@
       <form-fields :tile="tile" :deviceList="deviceList" />
 
       <input class="action-button" type="submit" value="save" />
+
+      <input
+        class="action-button action-button--secondary"
+        type="button"
+        value="cancel"
+        @click="cancelEditing"
+      />
     </form>
   </div>
 </template>
@@ -45,6 +52,10 @@ export default {
         eventData[name] = value;
       });
       this.$emit("save-settings", eventData);
+    },
+
+    cancelEditing() {
+      this.$emit("cancel-editing");
     }
   }
 };

--- a/public/js/components/CardForm.vue
+++ b/public/js/components/CardForm.vue
@@ -8,10 +8,10 @@
       <label>
         Title
         <input
-          v-focus="editing"
           type="text"
           name="title"
           v-bind:value="tile.title"
+          ref="firstFocusableElement"
         />
       </label>
 
@@ -23,16 +23,20 @@
 </template>
 
 <script>
-// focus management mixin
-import { focus } from "vue-focus";
 import FormFields from "./FormFields";
 import { Script } from "vm";
 
 export default {
   name: "card-form",
-  directives: { focus },
   components: { FormFields },
   props: ["tile", "deviceList", "editing"],
+  mounted() {
+    // After clicking the edit button, we need to focus the first focusable element in the form to
+    // make sure editing a card is keyboard-accessible.
+    this.$nextTick(function() {
+      this.$refs.firstFocusableElement.focus();
+    });
+  },
   methods: {
     onSubmit: function(event) {
       let eventData = {};

--- a/public/js/components/specs/App.spec.js
+++ b/public/js/components/specs/App.spec.js
@@ -62,26 +62,6 @@ describe("Number card", () => {
     expect(vm.simulating).toEqual(SIMULATING);
   });
 
-  test("computed value returned from dashStyle computed method", () => {
-    const { vm } = shallowMountApp();
-
-    vm.dashboard.bgImageRepeat = mockDashboardData.dashboard.bgImageRepeat;
-
-    expect(vm.dashStyle).toEqual({
-      "--background-color": vm.dashboard.bgColor,
-      backgroundImage: vm.dashboard.bgImageUrl,
-      backgroundRepeat: "repeat"
-    });
-
-    vm.dashboard.bgImageRepeat = false;
-
-    expect(vm.dashStyle).toEqual({
-      "--background-color": vm.dashboard.bgColor,
-      backgroundImage: vm.dashboard.bgImageUrl,
-      backgroundRepeat: "no-repeat"
-    });
-  });
-
   test("h1 heading style based upon headingStyle computed method", () => {
     const { vm } = shallowMountApp();
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,6 +2,8 @@ import Vue from "vue";
 import App from "./components/App";
 import VueA11yDialog from "vue-a11y-dialog";
 
+Vue.config.devtools = true;
+
 Vue.use(VueA11yDialog);
 
 new Vue({


### PR DESCRIPTION
I did some work on the overall behavior of card movement. This is partially related to #125.

- Card movement via mouse or keyboard is now capped off at the top-left corner. It simply stops there for the momement. There is no bouncy-back business. And no, I also did not add the Pokémon you’ve-hit-a-wall sound, but I think that it is an incredibly good idea to do so.
- Refactored the dragging code to avoid re-registering the `mousemove` event listener every time the card is clicked.
- Fixed a bug with keyboard navigation not emitting its new tile position which lead to the card position not being saved if it was moved the the keyboard last.
- All background styles of the dashboard are applied to the body element now to ensure that they extend to all available space on the page, not just the dimensions of the dashboard. For this, I needed to drop the related `dashStyle` test since this computed property no longer exists. I haven’t added adequate tests instead because I don’t know how (yet). See https://github.com/noopkat/electric-io/pull/127/commits/ba6bf412d26d6364d21a370eddbcacd4f2c8c2d7.
- Cards can no longer be moved while in editing mode. Allowing card movement in editing mode resulted in loss of data since the card component will be re-rendered when its data updates. Since a card’s position is part of its data, the card will be re-rendered with the currently stored data; thus, it dropped any data entered in the form fields.
- Cards can now be dragged with both mouse-based *and* touch-based pointer devices. See https://github.com/noopkat/electric-io/pull/127/commits/a01d262e157a1283e8d7da6f1bc0fc6b835f3030.
- A card’s editing form now has a cancel button that moves the card back into its viewing mode without saving any changes.

I had another idea:

While dragging, one could hold down `Shift` to snap to the card to a 10 pixel grid. What do you think about that?