### PR TITLE
Nested payload properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7607,6 +7607,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dotenv": "^8.0.0",
     "express": "^4.16.4",
     "express-sanitizer": "^1.0.5",
+    "jmespath": "^0.15.0",
     "marked": "^0.6.2",
     "socket.io": "^2.2.0",
     "vue": "^2.6.10",

--- a/public/js/components/LineChartCard.vue
+++ b/public/js/components/LineChartCard.vue
@@ -5,6 +5,7 @@
 <script>
 import Chart from "chart.js";
 import chartOptions from "../lib/chartOptions.js";
+import { evaluatePath } from "../lib/messagePropertyEvaluation.js";
 
 export default {
   name: "line-chart-card",
@@ -33,11 +34,14 @@ export default {
   },
   watch: {
     messages: function() {
-      const prop = this.tile.property;
+      const propPath = this.tile.property;
       const newData = this.messages
-        .filter(msg => msg[prop])
+        .filter(msg => evaluatePath(propPath, msg))
         .splice(-20)
-        .map(msg => ({ t: new Date(msg.enqueuedTime), y: msg[prop] }));
+        .map(msg => ({
+          t: new Date(msg.enqueuedTime),
+          y: evaluatePath(propPath, msg)
+        }));
       this.chartData.datasets[0].data = newData;
       this.chart.update();
     }

--- a/public/js/components/LineChartCard.vue
+++ b/public/js/components/LineChartCard.vue
@@ -36,12 +36,12 @@ export default {
     messages: function() {
       const propPath = this.tile.property;
       const newData = this.messages
-        .filter(msg => evaluatePath(propPath, msg))
-        .splice(-20)
         .map(msg => ({
           t: new Date(msg.enqueuedTime),
           y: evaluatePath(propPath, msg)
-        }));
+        }))
+        .filter(msg => msg.y)
+        .splice(-20);
       this.chartData.datasets[0].data = newData;
       this.chart.update();
     }

--- a/public/js/components/LineChartSettings.vue
+++ b/public/js/components/LineChartSettings.vue
@@ -13,7 +13,8 @@
     </label>
 
     <label>
-      Data Property
+      Data Property (supports
+      <a href="http://jmespath.org/tutorial.html" target="_blank">JMESPath</a>)
       <input type="text" name="property" :value="tile.property" />
     </label>
 

--- a/public/js/components/NumberCard.vue
+++ b/public/js/components/NumberCard.vue
@@ -3,6 +3,8 @@
 </template>
 
 <script>
+import { evaluatePath } from "../lib/messagePropertyEvaluation.js";
+
 export default {
   name: "number-card",
   props: {
@@ -24,9 +26,12 @@ export default {
   watch: {
     messages: function() {
       const lastMessage = this.messages.pop();
-      this.number = lastMessage
-        ? parseFloat(lastMessage[this.tile.property]).toFixed(1)
-        : 0;
+      if (lastMessage) {
+        const value = evaluatePath(this.tile.property, lastMessage);
+        this.number = parseFloat(value).toFixed(1);
+      } else {
+        this.number = 0;
+      }
     }
   },
   computed: {

--- a/public/js/components/NumberSettings.vue
+++ b/public/js/components/NumberSettings.vue
@@ -13,7 +13,8 @@
     </label>
 
     <label>
-      Data Property
+      Data Property (supports
+      <a href="http://jmespath.org/tutorial.html" target="_blank">JMESPath</a>)
       <input type="text" name="property" v-bind:value="tile.property" />
     </label>
 

--- a/public/js/lib/messagePropertyEvaluation.js
+++ b/public/js/lib/messagePropertyEvaluation.js
@@ -1,0 +1,27 @@
+import * as jmespath from "jmespath";
+
+/**
+ * Extract a value from an object or array.
+ *
+ * @param {string} path The path to the value to extract from the input value.
+ * @param {*} input The input value: an object or array.
+ *
+ * @remarks
+ * [JMESPath](http://jmespath.org/) syntax is supported.
+ */
+export function evaluatePath(path, input) {
+  if (!path) {
+    return null;
+  }
+
+  try {
+    return jmespath.search(input, path);
+  } catch (error) {
+    if (error.name === "ParserError") {
+      // TODO: The user entered a path that is not a valid JMESPath. This should be detected and prevented earlier in the card settings UI.
+      // Return no match.
+      return null;
+    }
+    throw error;
+  }
+}

--- a/public/js/lib/specs/messagePropertyEvaluation.spec.js
+++ b/public/js/lib/specs/messagePropertyEvaluation.spec.js
@@ -1,0 +1,68 @@
+import { evaluatePath } from "../messagePropertyEvaluation.js";
+
+describe("evaluatePath", () => {
+  const complexMessageBody = {
+    simpleProperty: 1,
+    objectProperty: {
+      int: 2,
+      arr: [3],
+      obj: {
+        value: 4
+      }
+    },
+    arrayProperty: [5, { value: 6 }]
+  };
+
+  test("Returns null with empty path", () => {
+    const value = evaluatePath("", complexMessageBody);
+    expect(value).toBeNull();
+  });
+
+  test("Returns null with invalid path", () => {
+    const value = evaluatePath(
+      "ceci nest pas une jmespath",
+      complexMessageBody
+    );
+    expect(value).toBeNull();
+  });
+
+  test("Returns null with undefined property", () => {
+    const value = evaluatePath("nonexistentProperty", complexMessageBody);
+    expect(value).toBeNull();
+  });
+
+  test("Returns null with undefined array index", () => {
+    const value = evaluatePath("arrayProperty[1234]", complexMessageBody);
+    expect(value).toBeNull();
+  });
+
+  test("Evaluates 'simpleProperty'", () => {
+    const value = evaluatePath("simpleProperty", complexMessageBody);
+    expect(value).toEqual(1);
+  });
+
+  test("Evaluates 'objectProperty.int'", () => {
+    const value = evaluatePath("objectProperty.int", complexMessageBody);
+    expect(value).toEqual(2);
+  });
+
+  test("Evaluates 'objectProperty.arr[0]'", () => {
+    const value = evaluatePath("objectProperty.arr[0]", complexMessageBody);
+    expect(value).toEqual(3);
+  });
+
+  test("Evaluates 'objectProperty.obj.value'", () => {
+    const value = evaluatePath("objectProperty.obj.value", complexMessageBody);
+    expect(value).toEqual(4);
+  });
+
+  test("Evaluates 'arrayProperty[0]'", () => {
+    const value = evaluatePath("arrayProperty[0]", complexMessageBody);
+    expect(value).toEqual(5);
+  });
+
+  test("Evaluates 'arrayProperty[1].value'", () => {
+    const value = evaluatePath("arrayProperty[1].value", complexMessageBody);
+    expect(value).toEqual(6);
+  });
+});


### PR DESCRIPTION
Hi @noopkat and friends :wave:,

I recently discovered your stream through a friend who is just starting out to code on Twitch. Seeing you and your community work together to build and learn is inspiring :star::gem:.

To give something back, I wanted to contribute a pull request that adds support for nested message payload properties and address issue #8 :gift:.

I usually don't tune in live because of time zones :australia::sleeping: but I'll see if I can work something out if this PR looks like it's getting close to a merge :coffee::coffee::coffee::coffee:.

-- Thomas

---

## Approach

I have replaced the existing code in `LineChartCard.vue` and `NumberCard.vue` that extracts a property value from the message according to the card's "Data Property" with a function that uses JMESPath.

### JMESPath

The [jmespath.js](https://github.com/jmespath/jmespath.js) library is a JavaScript implementation of [JMESPath](http://jmespath.org/): a way to select a (possibly nested) value from a JavaScript object or array. This is a new dependency added in this PR.

Although JMESPath is more powerful than we need for issue #8, it is conveniently backwards compatible with the current way cards use the "Data Property". Maybe the library's advanced features might come in handy when working with devices that send inconveniently complex messages.

Still, jmespath.js is quite modest compared to alternatives and has no dependencies. Webpack reports that it increases the bundle size by about 21 KiB (when built with `--production`).

jmespath.js uses the [Apache-2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).

### Errors

An invalid path would silently cause no values to appear on the card, similar to what happens today if the property is missing from a message. In future, we can look at preventing invalid paths by checking that the "Data Property" is a valid JMESPath in the card settings UI.

As before, if you select a value from the message that is not a number, the card won't display it.

### Performance

The line chart re-evaluates all messages (up to the 500 limit) every tick and discards all but the last 20 that are truthy. This is a bit wasteful but I didn't want to refactor this unless we know for sure it's a problem.

### Compatibility

#### Existing dashboards

This change should be almost completely backwards compatible - I believe most existing dashboard configurations should work with no modifications. The exception would be dashboards that use message properties whose names contain characters that are [special to JMESPath](http://jmespath.org/specification.html). These are mostly non-alphanumeric characters that would be ridiculous to use in property names anyway.

#### MQTT

This change is all about JavaScript objects and JSON but I have no idea if/how this might affect the work in progress on MQTT. I'm actually not all that familiar with IoT :sweat_smile:.

## Testing

I have included tests for the new function.

However, it didn't seem right to add nested properties to the simulation mode as they appear to be modelled on real devices, so I left the simulation mode alone. Let me know if you'd like me to add some nested objects to the simulation mode.

Otherwise, you can test using Azure IoT Hub and the simulated device in the [Azure IoT Hub Quickstart](https://github.com/Azure-Samples/azure-iot-samples-node). Change [this line in the simulated device](https://github.com/Azure-Samples/azure-iot-samples-node/blob/c3abae6b766338db8530d727abe1ecbf94aab696/iot-hub/Quickstarts/simulated-device/SimulatedDevice.js#L32-L35) to send messages with nested objects or arrays. This is how I recorded the demo below.

## Demo

![nested-properties-demo.gif](https://user-images.githubusercontent.com/9063335/60331545-3d2f3380-99d8-11e9-8314-a53de12477a0.gif)

## Examples

- `temperature` the "temperature" property
- `samples[0]` the 0th value in the "samples" array
- `measurement.humidity` the "humidity" property of the "measurement" object

See the [JMESPath tutorial](http://jmespath.org/tutorial.html) and [JMESPath examples](http://jmespath.org/examples.html) for more.

