### PR TITLE
Added Short Hex Color Code parsing to RGB in Color Contraster

### DIFF
--- a/public/js/lib/colorContraster.js
+++ b/public/js/lib/colorContraster.js
@@ -83,27 +83,16 @@ function validHexColor(inputHexString) {
   // check if string is either 4 or 7 characters long and is string
   // added 9 for #RGBA types value (we remove alpha part later using substring)
   // Also, RGBA don't have short code
-  if (
-    ![4, 7, 9].includes(inputHexString.length) ||
-    typeof inputHexString !== "string"
-  ) {
+  // Edit: Removed string check as it doesn't make sense here
+  if (![4, 7, 9].includes(inputHexString.length)) {
     return false;
   }
 
   // Another small check to validate valid HEX input
-  // 1. Remove '#' from string
-  // 2. Split into array of chars
-  // 3. Map over each entry to check if parseInt with base 16 yields valid number
-  // 4. Finally test if a NaN is present.
-  // If NaN were present, this condition will be true implying invalid Hex code
-  // It might be an overkill here
-  if (
-    Array.from(inputHexString.substr(1)).find(char =>
-      isNaN(parseInt(char, 16))
-    ) !== undefined
-  ) {
-    return false;
-  }
+  // A simple Regular Expression can handle the validation here
 
-  return true;
+  // 1 or more characters between 0-f both cases (captial and small)
+  const exp = /^[a-fA-F0-9]+$/;
+
+  return exp.test(inputHexString.substr(1));
 }

--- a/public/js/lib/colorContraster.js
+++ b/public/js/lib/colorContraster.js
@@ -31,7 +31,7 @@ function parseColor(color) {
 
 function parseHex(color) {
   // #ff00de
-  const r; const g; const b, const justColor;
+  let r; let g; let b; let justColor;
   
   // need to check here if a 3 digit short hex code is provided
   // We're assuming here that the color will always be 

--- a/public/js/lib/colorContraster.js
+++ b/public/js/lib/colorContraster.js
@@ -11,7 +11,12 @@ export default function pickTextColorBasedOnBgColor(
   darkColor
 ) {
   if (!bgColor) return "#000000";
-  const { r, g, b } = parseColor(bgColor);
+  const rgb = parseColor(bgColor);
+  if (rgb === null) {
+    return null;
+  }
+
+  const { r, g, b } = rgb;
   const uicolors = [r / 255, g / 255, b / 255];
   const c = uicolors.map(col => {
     if (col <= 0.03928) {
@@ -31,37 +36,21 @@ function parseColor(color) {
 
 function parseHex(color) {
   // #ff00de
-  
-  // adding a simple error check in case of an invalid color string
-  // check if string is either 4 or 7 characters long and is string
-  // added 9 for #RGBA types value (we remove alpha part later using substring) 
-  // Also, RGBA don't have short code
-  if (!([4, 7, 9].includes(color.length)) || typeof color !== "string") {
+  // validate and return if invalid
+  if (!validHexColor(color)) {
     return null;
   }
-  // Another small check to validate valid HEX input
-  // 1. Remove '#' from string
-  // 2. Split into array of chars
-  // 3. Map over each entry to check if parseInt with base 16 yields valid number
-  // 4. Finally test if a NaN is present.
-  // If NaN were present, this condition will be true implying invalid Hex code
-  // It might be an overkill here
-  if (Array.from(color.substr(1))
-       .map(b => isNaN(parseInt(b, 16)))
-       .indexOf(true) !== -1) {
-     return null;
-  }
-  
+
   let r, g, b, justColor;
-  
+
   // need to check here if a 3 digit short hex code is provided
-  // We're assuming here that the color will always be 
+  // We're assuming here that the color will always be
   // (simple string length test would do)
   if (color.length === 4) {
     justColor = color.substring(1, 4);
-    r = parseInt(justColor.substring(0,1).repeat(2), 16); // hextToR
-    g = parseInt(justColor.substring(1,2).repeat(2), 16); // hextToG
-    b = parseInt(justColor.substring(2,3).repeat(2), 16); // hextToR
+    r = parseInt(justColor.substring(0, 1).repeat(2), 16); // hextToR
+    g = parseInt(justColor.substring(1, 2).repeat(2), 16); // hextToG
+    b = parseInt(justColor.substring(2, 3).repeat(2), 16); // hextToR
   } else {
     justColor = color.substring(1, 7);
     r = parseInt(justColor.substring(0, 2), 16); // hexToR
@@ -84,4 +73,37 @@ function parseName(color) {
   const justColor = color.replace(/\s/g, "").toLowerCase();
   const hexColor = colorNames[color];
   return parseHex(hexColor);
+}
+
+function validHexColor(inputHexString) {
+  // returns true or false depending on validity of input string
+  // I've divided the check into two steps for code readability
+
+  // adding a simple error check in case of an invalid color string
+  // check if string is either 4 or 7 characters long and is string
+  // added 9 for #RGBA types value (we remove alpha part later using substring)
+  // Also, RGBA don't have short code
+  if (
+    ![4, 7, 9].includes(inputHexString.length) ||
+    typeof inputHexString !== "string"
+  ) {
+    return false;
+  }
+
+  // Another small check to validate valid HEX input
+  // 1. Remove '#' from string
+  // 2. Split into array of chars
+  // 3. Map over each entry to check if parseInt with base 16 yields valid number
+  // 4. Finally test if a NaN is present.
+  // If NaN were present, this condition will be true implying invalid Hex code
+  // It might be an overkill here
+  if (
+    Array.from(inputHexString.substr(1)).find(char =>
+      isNaN(parseInt(char, 16))
+    ) !== undefined
+  ) {
+    return false;
+  }
+
+  return true;
 }

--- a/public/js/lib/colorContraster.js
+++ b/public/js/lib/colorContraster.js
@@ -36,7 +36,7 @@ function parseHex(color) {
   // check if string is either 4 or 7 characters long and is string
   // added 9 for #RGBA types value (we remove alpha part later using substring) 
   // Also, RGBA don't have short code
-  if ([4, 7, 9].includes(color.length) && typeof color === "string") {
+  if (!([4, 7, 9].includes(color.length)) || typeof color !== "string") {
     return null;
   }
   // Another small check to validate valid HEX input

--- a/public/js/lib/colorContraster.js
+++ b/public/js/lib/colorContraster.js
@@ -31,12 +31,24 @@ function parseColor(color) {
 
 function parseHex(color) {
   // #ff00de
-  // support for 3 character hex strings would be nice :)
-  // pull request me if you like - noopkat
-  const justColor = color.substring(1, 7);
-  const r = parseInt(justColor.substring(0, 2), 16); // hexToR
-  const g = parseInt(justColor.substring(2, 4), 16); // hexToG
-  const b = parseInt(justColor.substring(4, 6), 16); // hexToB
+  const r; const g; const b, const justColor;
+  
+  // need to check here if a 3 digit short hex code is provided
+  // We're assuming here that the color will always be 
+  // (simple string length test would do)
+  if (color.length === 4) {
+    justColor = color.substring(1, 4);
+    // Using [String.prototype.repeat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat)
+    r = parseInt(justColor.substring(0,1).repeat(2), 16); // hextToR
+    g = parseInt(justColor.substring(1,2).repeat(2), 16); // hextToG
+    b = parseInt(justColor.substring(2,3).repeat(2), 16); // hextToR
+  } else {
+    justColor = color.substring(1, 7);
+    r = parseInt(justColor.substring(0, 2), 16); // hexToR
+    g = parseInt(justColor.substring(2, 4), 16); // hexToG
+    b = parseInt(justColor.substring(4, 6), 16); // hexToB
+  }
+
   return { r, g, b };
 }
 

--- a/public/js/lib/colorContraster.js
+++ b/public/js/lib/colorContraster.js
@@ -31,14 +31,34 @@ function parseColor(color) {
 
 function parseHex(color) {
   // #ff00de
-  let r,  g, b,  justColor;
+  
+  // adding a simple error check in case of an invalid color string
+  // check if string is either 4 or 7 characters long and is string
+  // added 9 for #RGBA types value (we remove alpha part later using substring) 
+  // Also, RGBA don't have short code
+  if ([4, 7, 9].includes(color.length) && typeof color === "string") {
+    return null;
+  }
+  // Another small check to validate valid HEX input
+  // 1. Remove '#' from string
+  // 2. Split into array of chars
+  // 3. Map over each entry to check if parseInt with base 16 yields valid number
+  // 4. Finally test if a NaN is present.
+  // If NaN were present, this condition will be true implying invalid Hex code
+  // It might be an overkill here
+  if (Array.from(color.substr(1))
+       .map(b => isNaN(parseInt(b, 16)))
+       .indexOf(true) !== -1) {
+     return null;
+  }
+  
+  let r, g, b, justColor;
   
   // need to check here if a 3 digit short hex code is provided
   // We're assuming here that the color will always be 
   // (simple string length test would do)
   if (color.length === 4) {
     justColor = color.substring(1, 4);
-    // Using [String.prototype.repeat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat)
     r = parseInt(justColor.substring(0,1).repeat(2), 16); // hextToR
     g = parseInt(justColor.substring(1,2).repeat(2), 16); // hextToG
     b = parseInt(justColor.substring(2,3).repeat(2), 16); // hextToR

--- a/public/js/lib/colorContraster.js
+++ b/public/js/lib/colorContraster.js
@@ -31,7 +31,7 @@ function parseColor(color) {
 
 function parseHex(color) {
   // #ff00de
-  let r; let g; let b; let justColor;
+  let r,  g, b,  justColor;
   
   // need to check here if a 3 digit short hex code is provided
   // We're assuming here that the color will always be 

--- a/public/js/lib/specs/colorContraster.spec.js
+++ b/public/js/lib/specs/colorContraster.spec.js
@@ -15,9 +15,17 @@ describe("colorContrast checker", () => {
     test("Return dark colour given light", () => {
       expect(colorContrastCheck("#ffefd5", "white", "black")).toBe("black");
     });
+    
+    test("Return dark color given light (short hex code)", () => {
+      expect(colorContrastCheck("#fed", "white", "black")).toBe("black");
+    });
 
     test("Return light colour given dark", () => {
       expect(colorContrastCheck("#800080", "white", "black")).toBe("white");
+    });
+    
+    test("Return light color given dark (short hex code)", () => {
+      expect(colorContrastCheck("#352", "white", "black")).toBe("white");
     });
   });
 

--- a/public/js/lib/specs/colorContraster.spec.js
+++ b/public/js/lib/specs/colorContraster.spec.js
@@ -15,7 +15,7 @@ describe("colorContrast checker", () => {
     test("Return dark colour given light", () => {
       expect(colorContrastCheck("#ffefd5", "white", "black")).toBe("black");
     });
-    
+
     test("Return dark color given light (short hex code)", () => {
       expect(colorContrastCheck("#fed", "white", "black")).toBe("black");
     });
@@ -23,9 +23,13 @@ describe("colorContrast checker", () => {
     test("Return light colour given dark", () => {
       expect(colorContrastCheck("#800080", "white", "black")).toBe("white");
     });
-    
+
     test("Return light color given dark (short hex code)", () => {
       expect(colorContrastCheck("#352", "white", "black")).toBe("white");
+    });
+
+    test("Return null on invalid hex code input", () => {
+      expect(colorContrastCheck("#GGG", "white", "black")).toBe(null);
     });
   });
 


### PR DESCRIPTION
In `colorContraster.js` I've added the logic to process short HEX color code. I've used `String.prototype.repeat` but I doubt we need to add some polyfill for IE support for that. 

Please advice.