### PR TITLE
Validate data property input on card settings

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -12,6 +12,9 @@
   --focus-color: hotpink;
   --focus-outline: 2px solid var(--focus-color);
   --focus-box-shadow: 0 0 0 2px var(--focus-color);
+
+  --invalid-color: #da2727;
+  --invalid-focus-outline: 2px solid var(--invalid-color);
 }
 
 html,
@@ -30,6 +33,10 @@ body {
 
 :focus {
   outline: var(--focus-outline);
+}
+
+.invalid :focus {
+  outline: var(--invalid-focus-outline);
 }
 
 .bold {
@@ -336,6 +343,7 @@ input {
 label {
   font-size: 13px;
   display: block;
+  margin-bottom: 10px;
 }
 
 select {
@@ -349,6 +357,10 @@ select {
   margin-top: -7px;
   margin-bottom: 15px;
   display: block;
+}
+
+.cardForm .invalid {
+  color: var(--invalid-color);
 }
 
 /* -------------- */

--- a/public/js/components/DataPropertyField.vue
+++ b/public/js/components/DataPropertyField.vue
@@ -1,17 +1,20 @@
 <template>
-  <label v-bind:for="inputId" v-bind:class="{ invalid: !isValid }">
+  <label v-bind:for="inputElementId" v-bind:class="{ invalid: !isValid }">
     Data Property (supports
     <a href="http://jmespath.org/tutorial.html" target="_blank" rel="noopener"
       >JMESPath</a
     >)
     <input
       type="text"
-      v-bind:id="inputId"
+      v-bind:id="inputElementId"
       v-bind:name="name"
       v-model="model"
       v-bind:aria-invalid="!isValid"
+      v-bind:aria-describedby="!isValid ? errorElementId : null"
     />
-    <span v-if="!isValid">This is not a valid JMESPath.</span>
+    <span v-bind:id="errorElementId" v-if="!isValid"
+      >This is not a valid JMESPath.</span
+    >
   </label>
 </template>
 
@@ -33,8 +36,11 @@ export default {
     isValid: function() {
       return pathIsValid(this.model);
     },
-    inputId: function() {
+    inputElementId: function() {
       return `data-property-input-${this.tileId}`;
+    },
+    errorElementId: function() {
+      return `data-property-error-${this.tileId}`;
     }
   }
 };

--- a/public/js/components/DataPropertyField.vue
+++ b/public/js/components/DataPropertyField.vue
@@ -1,21 +1,28 @@
 <template>
   <label v-bind:class="{ invalid: !isValid }">
     Data Property (supports
-    <a href="http://jmespath.org/tutorial.html" target="_blank">JMESPath</a>)
-    <input type="text" v-bind:name="name" v-model="model" v-bind:aria-invalid="!isValid" />
+    <a href="http://jmespath.org/tutorial.html" target="_blank" rel="noopener"
+      >JMESPath</a
+    >)
+    <input
+      type="text"
+      v-bind:name="name"
+      v-model="model"
+      v-bind:aria-invalid="!isValid"
+    />
     <span v-if="!isValid">This is not a valid JMESPath.</span>
   </label>
 </template>
 
 <script>
-import { pathIsValid } from '../lib/messagePropertyEvaluation.js';
+import { pathIsValid } from "../lib/messagePropertyEvaluation.js";
 
 export default {
   name: "data-property-field",
   props: ["name", "value"],
   data() {
     return {
-      model: "",
+      model: ""
     };
   },
   mounted() {

--- a/public/js/components/DataPropertyField.vue
+++ b/public/js/components/DataPropertyField.vue
@@ -1,11 +1,12 @@
 <template>
-  <label v-bind:class="{ invalid: !isValid }">
+  <label v-bind:for="inputId" v-bind:class="{ invalid: !isValid }">
     Data Property (supports
     <a href="http://jmespath.org/tutorial.html" target="_blank" rel="noopener"
       >JMESPath</a
     >)
     <input
       type="text"
+      v-bind:id="inputId"
       v-bind:name="name"
       v-model="model"
       v-bind:aria-invalid="!isValid"
@@ -19,7 +20,7 @@ import { pathIsValid } from "../lib/messagePropertyEvaluation.js";
 
 export default {
   name: "data-property-field",
-  props: ["name", "value"],
+  props: ["tileId", "name", "value"],
   data() {
     return {
       model: ""
@@ -31,6 +32,9 @@ export default {
   computed: {
     isValid: function() {
       return pathIsValid(this.model);
+    },
+    inputId: function() {
+      return `data-property-input-${this.tileId}`;
     }
   }
 };

--- a/public/js/components/DataPropertyField.vue
+++ b/public/js/components/DataPropertyField.vue
@@ -1,0 +1,30 @@
+<template>
+  <label v-bind:class="{ invalid: !isValid }">
+    Data Property (supports
+    <a href="http://jmespath.org/tutorial.html" target="_blank">JMESPath</a>)
+    <input type="text" v-bind:name="name" v-model="model" v-bind:aria-invalid="!isValid" />
+    <span v-if="!isValid">This is not a valid JMESPath.</span>
+  </label>
+</template>
+
+<script>
+import { pathIsValid } from '../lib/messagePropertyEvaluation.js';
+
+export default {
+  name: "data-property-field",
+  props: ["name", "value"],
+  data() {
+    return {
+      model: "",
+    };
+  },
+  mounted() {
+    this.model = this.value;
+  },
+  computed: {
+    isValid: function() {
+      return pathIsValid(this.model);
+    }
+  }
+};
+</script>

--- a/public/js/components/LineChartSettings.vue
+++ b/public/js/components/LineChartSettings.vue
@@ -13,7 +13,11 @@
       </select>
     </label>
 
-    <data-property-field name="property" v-bind:value="tile.property" />
+    <data-property-field
+      name="property"
+      v-bind:value="tile.property"
+      v-bind:tileId="tile.id"
+    />
 
     <label>
       Line Color

--- a/public/js/components/LineChartSettings.vue
+++ b/public/js/components/LineChartSettings.vue
@@ -13,11 +13,7 @@
       </select>
     </label>
 
-    <label>
-      Data Property (supports
-      <a href="http://jmespath.org/tutorial.html" target="_blank">JMESPath</a>)
-      <input type="text" name="property" :value="tile.property" />
-    </label>
+    <data-property-field name="property" v-bind:value="tile.property" />
 
     <label>
       Line Color
@@ -27,8 +23,11 @@
 </template>
 
 <script>
+import DataPropertyField from "./DataPropertyField";
+
 export default {
   name: "line-chart-settings",
+  components: { DataPropertyField },
   props: ["tile", "deviceList"]
 };
 </script>

--- a/public/js/components/NumberCard.vue
+++ b/public/js/components/NumberCard.vue
@@ -28,7 +28,7 @@ export default {
       const lastMessage = this.messages.pop();
       if (lastMessage) {
         const value = evaluatePath(this.tile.property, lastMessage);
-        this.number = value === null ? "" : parseFloat(value).toFixed(1);
+        this.number = parseFloat(value).toFixed(1);
       } else {
         this.number = 0;
       }

--- a/public/js/components/NumberCard.vue
+++ b/public/js/components/NumberCard.vue
@@ -28,7 +28,7 @@ export default {
       const lastMessage = this.messages.pop();
       if (lastMessage) {
         const value = evaluatePath(this.tile.property, lastMessage);
-        this.number = parseFloat(value).toFixed(1);
+        this.number = value ? parseFloat(value).toFixed(1) : "";
       } else {
         this.number = 0;
       }

--- a/public/js/components/NumberCard.vue
+++ b/public/js/components/NumberCard.vue
@@ -28,7 +28,7 @@ export default {
       const lastMessage = this.messages.pop();
       if (lastMessage) {
         const value = evaluatePath(this.tile.property, lastMessage);
-        this.number = value ? parseFloat(value).toFixed(1) : "";
+        this.number = value === null ? "" : parseFloat(value).toFixed(1);
       } else {
         this.number = 0;
       }

--- a/public/js/components/NumberSettings.vue
+++ b/public/js/components/NumberSettings.vue
@@ -12,11 +12,7 @@
       </select>
     </label>
 
-    <label>
-      Data Property (supports
-      <a href="http://jmespath.org/tutorial.html" target="_blank">JMESPath</a>)
-      <input type="text" name="property" v-bind:value="tile.property" />
-    </label>
+    <data-property-field name="property" v-bind:value="tile.property" />
 
     <label>
       Text Color
@@ -26,8 +22,11 @@
 </template>
 
 <script>
+import DataPropertyField from "./DataPropertyField";
+
 export default {
   name: "number-settings",
+  components: { DataPropertyField },
   props: ["tile", "deviceList"]
 };
 </script>

--- a/public/js/components/NumberSettings.vue
+++ b/public/js/components/NumberSettings.vue
@@ -12,7 +12,11 @@
       </select>
     </label>
 
-    <data-property-field name="property" v-bind:value="tile.property" />
+    <data-property-field
+      name="property"
+      v-bind:value="tile.property"
+      v-bind:tileId="tile.id"
+    />
 
     <label>
       Text Color

--- a/public/js/components/specs/DataPropertyField.spec.js
+++ b/public/js/components/specs/DataPropertyField.spec.js
@@ -1,0 +1,63 @@
+import { shallowMount } from "@vue/test-utils";
+import axe from "axe-core";
+import DataPropertyField from "../DataPropertyField";
+
+describe("DataPropertyField", () => {
+  test("component can mount", () => {
+    const wrapper = shallowMountDataPropertyField("property", "");
+
+    expect(wrapper.isVueInstance()).toBeTruthy();
+  });
+
+  test("has one input element with the expected name", () => {
+    const wrapper = shallowMountDataPropertyField("unusual-property", "");
+
+    const inputs = wrapper.findAll("input[name=unusual-property]");
+
+    expect(inputs.exists()).toBe(true);
+    expect(inputs.length).toEqual(1);
+  });
+
+  describe("given valid input", () => {
+    const validValue = "this.is.a.valid.value";
+
+    test("has aria-invalid attribute unset", () => {
+      const wrapper = shallowMountDataPropertyField("property", validValue);
+
+      const input = wrapper.find("input[name=property]");
+
+      expect(input.attributes("aria-invalid")).toBeUndefined();
+    });
+  });
+
+  describe("given invalid input", () => {
+    const invalidValue = "this is not a valid value";
+
+    test("has aria-invalid attribute set to 'true'", () => {
+      const wrapper = shallowMountDataPropertyField("property", invalidValue);
+
+      const input = wrapper.find("input[name=property]");
+
+      expect(input.attributes("aria-invalid")).toEqual("true");
+    });
+  });
+
+  test("verify component is accessible", () => {
+    const wrapper = shallowMountDataPropertyField("property", "value");
+
+    axe.run(wrapper, (err, { violations }) => {
+      expect(err).toBe(null);
+      expect(violations).toHaveLength(0);
+      done();
+    });
+  });
+});
+
+function shallowMountDataPropertyField(name, value) {
+  return shallowMount(DataPropertyField, {
+    propsData: {
+      name: name,
+      value: value
+    }
+  });
+}

--- a/public/js/components/specs/DataPropertyField.spec.js
+++ b/public/js/components/specs/DataPropertyField.spec.js
@@ -28,6 +28,14 @@ describe("DataPropertyField", () => {
 
       expect(input.attributes("aria-invalid")).toBeUndefined();
     });
+
+    test("has aria-describedby attribute unset", () => {
+      const wrapper = shallowMountDataPropertyField("property", validValue, "");
+
+      const input = wrapper.find("input[name=property]");
+
+      expect(input.attributes("aria-describedby")).toBeUndefined();
+    });
   });
 
   describe("given invalid input", () => {
@@ -43,6 +51,21 @@ describe("DataPropertyField", () => {
       const input = wrapper.find("input[name=property]");
 
       expect(input.attributes("aria-invalid")).toEqual("true");
+    });
+
+    test("has aria-describedby attribute set to an element that exists in the component", () => {
+      const wrapper = shallowMountDataPropertyField(
+        "property",
+        invalidValue,
+        ""
+      );
+
+      const input = wrapper.find("input[name=property]");
+      const attributeValue = input.attributes("aria-describedby");
+      const describedByElements = wrapper.findAll(`#${attributeValue}`);
+
+      expect(describedByElements.exists()).toBe(true);
+      expect(describedByElements.length).toEqual(1);
     });
   });
 

--- a/public/js/components/specs/DataPropertyField.spec.js
+++ b/public/js/components/specs/DataPropertyField.spec.js
@@ -4,13 +4,13 @@ import DataPropertyField from "../DataPropertyField";
 
 describe("DataPropertyField", () => {
   test("component can mount", () => {
-    const wrapper = shallowMountDataPropertyField("property", "");
+    const wrapper = shallowMountDataPropertyField("property", "", "");
 
     expect(wrapper.isVueInstance()).toBeTruthy();
   });
 
   test("has one input element with the expected name", () => {
-    const wrapper = shallowMountDataPropertyField("unusual-property", "");
+    const wrapper = shallowMountDataPropertyField("unusual-property", "", "");
 
     const inputs = wrapper.findAll("input[name=unusual-property]");
 
@@ -22,7 +22,7 @@ describe("DataPropertyField", () => {
     const validValue = "this.is.a.valid.value";
 
     test("has aria-invalid attribute unset", () => {
-      const wrapper = shallowMountDataPropertyField("property", validValue);
+      const wrapper = shallowMountDataPropertyField("property", validValue, "");
 
       const input = wrapper.find("input[name=property]");
 
@@ -34,7 +34,11 @@ describe("DataPropertyField", () => {
     const invalidValue = "this is not a valid value";
 
     test("has aria-invalid attribute set to 'true'", () => {
-      const wrapper = shallowMountDataPropertyField("property", invalidValue);
+      const wrapper = shallowMountDataPropertyField(
+        "property",
+        invalidValue,
+        ""
+      );
 
       const input = wrapper.find("input[name=property]");
 
@@ -43,7 +47,7 @@ describe("DataPropertyField", () => {
   });
 
   test("verify component is accessible", () => {
-    const wrapper = shallowMountDataPropertyField("property", "value");
+    const wrapper = shallowMountDataPropertyField("property", "value", "");
 
     axe.run(wrapper, (err, { violations }) => {
       expect(err).toBe(null);
@@ -53,11 +57,12 @@ describe("DataPropertyField", () => {
   });
 });
 
-function shallowMountDataPropertyField(name, value) {
+function shallowMountDataPropertyField(name, value, tileId) {
   return shallowMount(DataPropertyField, {
     propsData: {
       name: name,
-      value: value
+      value: value,
+      tileId: tileId
     }
   });
 }

--- a/public/js/components/specs/LineChartSettings.spec.js
+++ b/public/js/components/specs/LineChartSettings.spec.js
@@ -15,14 +15,33 @@ describe("LineChartSettings", () => {
     expect(vm.deviceList.length).toBe(3);
   });
 
-  test("that there are 3 labels in the LineChartSettings window", () => {
+  test("that there is a device ID field in the LineChartSettings window", () => {
     const wrapper = shallowMountLineChartSettings();
 
-    const labels = wrapper.findAll("label");
+    const elements = wrapper.findAll("[name=deviceId]");
 
-    expect(labels.exists()).toBe(true);
-    expect(labels.length).toEqual(3);
+    expect(elements.exists()).toBe(true);
+    expect(elements.length).toEqual(1);
   });
+
+  test("that there is a data property field in the LineChartSettings window", () => {
+    const wrapper = shallowMountLineChartSettings();
+
+    const elements = wrapper.findAll("[name=property]");
+
+    expect(elements.exists()).toBe(true);
+    expect(elements.length).toEqual(1);
+  });
+
+  test("that there is a line color field in the LineChartSettings window", () => {
+    const wrapper = shallowMountLineChartSettings();
+
+    const elements = wrapper.findAll("[name=lineColor]");
+
+    expect(elements.exists()).toBe(true);
+    expect(elements.length).toEqual(1);
+  });
+
   test("verify component is accessible", () => {
     const wrapper = shallowMountLineChartSettings();
 

--- a/public/js/lib/messagePropertyEvaluation.js
+++ b/public/js/lib/messagePropertyEvaluation.js
@@ -40,15 +40,16 @@ function evaluate(path, input) {
     const value = jmespath.search(input, path);
     return { value: value, isValidPath: true };
   } catch (error) {
-    switch ((error.name || "").toLowerCase()) {
-      case "lexererror":
-      case "parsererror":
-      case "runtimeerror":
-        // The user entered a path that is not a valid JMESPath.
-        // Return error.
-        return { value: null, isValidPath: false };
-      default:
-        throw error;
+    const errorName = (error.name || "").toLowerCase();
+    if (
+      errorName === "lexererror" ||
+      errorName === "parsererror" ||
+      errorName === "runtimeerror"
+    ) {
+      // The user entered a path that is not a valid JMESPath.
+      // Return error.
+      return { value: null, isValidPath: false };
     }
+    throw error;
   }
 }

--- a/public/js/lib/messagePropertyEvaluation.js
+++ b/public/js/lib/messagePropertyEvaluation.js
@@ -10,18 +10,45 @@ import * as jmespath from "jmespath";
  * [JMESPath](http://jmespath.org/) syntax is supported.
  */
 export function evaluatePath(path, input) {
+  return evaluate(path, input).value;
+}
+
+/**
+ * Test that the argument is a valid path for evaluatePath.
+ *
+ * @param path {string} The path to validate.
+ */
+export function pathIsValid(path) {
+  return evaluate(path, {}).isValidPath;
+}
+
+function evaluate(path, input) {
   if (!path) {
-    return null;
+    // Falsy paths are valid.
+    // Return null to show an empty card.
+    return { value: null, isValidPath: true };
+  }
+
+  if (path.substring(path.length - 1) === ".") {
+    // jmespath.js has a bug where paths ending in "." aren't rejected by the parser.
+    // https://github.com/jmespath/jmespath.js/issues/36
+    // Return error.
+    return { value: null, isValidPath: false };
   }
 
   try {
-    return jmespath.search(input, path);
+    const value = jmespath.search(input, path);
+    return { value: value, isValidPath: true };
   } catch (error) {
-    if (error.name === "ParserError") {
-      // TODO: The user entered a path that is not a valid JMESPath. This should be detected and prevented earlier in the card settings UI.
-      // Return no match.
-      return null;
+    switch ((error.name || "").toLowerCase()) {
+      case "lexererror":
+      case "parsererror":
+      case "runtimeerror":
+        // The user entered a path that is not a valid JMESPath.
+        // Return error.
+        return { value: null, isValidPath: false };
+      default:
+        throw error;
     }
-    throw error;
   }
 }

--- a/public/js/lib/specs/messagePropertyEvaluation.spec.js
+++ b/public/js/lib/specs/messagePropertyEvaluation.spec.js
@@ -1,4 +1,4 @@
-import { evaluatePath } from "../messagePropertyEvaluation.js";
+import { evaluatePath, pathIsValid } from "../messagePropertyEvaluation.js";
 
 describe("evaluatePath", () => {
   const complexMessageBody = {
@@ -64,5 +64,19 @@ describe("evaluatePath", () => {
   test("Evaluates 'arrayProperty[1].value'", () => {
     const value = evaluatePath("arrayProperty[1].value", complexMessageBody);
     expect(value).toEqual(6);
+  });
+});
+
+describe("pathIsValid", () => {
+  test("returns true for empty path", () => {
+    expect(pathIsValid("")).toEqual(true);
+  }),
+
+  test("returns false for '['", () => {
+    expect(pathIsValid("[")).toEqual(false);
+  });
+
+  test("returns false for 'prop.'", () => {
+    expect(pathIsValid("prop.")).toEqual(false);
   });
 });


### PR DESCRIPTION
Hi @noopkat and team,

I was so pleased with the positive reactions to my previous contribution :joy: that the temptation to submit another bougie pull request was just too great! :tada:

I also felt bad for increasing the net number of `TODO` comments in electric-io with #128 :disappointed:

---

This pull request adds validation to the settings form for the number card and line chart card so that users know when their data property is not a valid JMESPath.

## Pics or it didn't happen

![eio-not-a-jmespath.gif](https://user-images.githubusercontent.com/9063335/61115307-86ea4480-a4d5-11e9-9674-e024839437b9.gif)

## New component

To reduce duplication in the view, there is a new component for the data property field shared by both the number card and line chart card settings forms.

![eio-data-property-field-component-valid.png](https://user-images.githubusercontent.com/9063335/61131116-ad22db00-a4fb-11e9-8bea-748875c97680.png)
![eio-data-property-field-component-invalid.png](https://user-images.githubusercontent.com/9063335/61131213-f2470d00-a4fb-11e9-8ee8-b1e3ed351537.png)

The component validates the data property input and displays a message beside the field if it is invalid.

There is a CSS variable for the colour - nice fire engine red - but it clashes a bit with the hot pink focus outline. You can also see that the card grows taller when the error message is visible, which I'm not a fan of. Suggestions for improving the visual design are very welcome! **Roast my Vue!** :sweat_smile:

## Accessibility

The `aria-invalid` and `aria-describedby` attributes are set on the data property field when the value is invalid.

![eio-not-a-jmespath-aria-2](https://user-images.githubusercontent.com/9063335/61179094-cda77e00-a63e-11e9-95d3-3d40cac817b9.gif)

Note also that an invalid data property value does not prevent the card from being saved. I offer you two excuses for this: :grin:

1. I don't know Vue.js very well and couldn't figure out how to make it work :dizzy_face: !

2. I believe it's a more human-friendly experience to the let users experiment safely and save their work, even if it's incomplete. Since a mistake is reversible and an invalid input only causes a harmless empty/zero card, Electric-IO won't break and the user won't damage their dashboard permanently. Form validation on the web is notorious for poor design and putting up walls in front of the user does them no favours here. However, feedback on the _front_ of the card that something is wrong in the settings would be an improvement to think about later.

I sadly do not encounter many opportunities to work on accessible software in my day job (because "enterprise" :weary:) so I'm a bit out of my depth about what to do for users using accessibility aids. So please, **roast my a11y too!** :sweat_smile:

## Changes to messagePathEvaluation.js

I have added a `pathIsValid` function to `messagePathEvaluation.js` for components to use.

However, while extending `messagePathEvaluation.js` to support validation, I encountered one bug of my own making and two bugs in jmespath.js:

1. It was only catching `ParserError`, but jmespath.js also throws `LexerError` and `RuntimeError` if things go awry. The function now accounts for all three of these errors.

2. The parser in jmespath.js throws `Parsererror` (sic) in one of its branches ([source code](https://github.com/jmespath/jmespath.js/blob/b16deb4f32270b2c75c08460e6afd2b064547a2a/jmespath.js#L764)), hence my use of `toLowerCase` to catch these.

3. The parser in jmespath.js also fails to reject a path ending in a `.` which causes an unseemly `TypeError` in the console later. This is [already reported](https://github.com/jmespath/jmespath.js/issues/36) upstream but not fixed. I worked around this.

Overall, the apparent lack of attention to the issues and open PRs on jmespath.js makes me a little bit nervous about it - I first heard of JMESPath while working with the Azure CLI (Python) - but I haven't encountered anything yet in jmespath.js we can't easily avoid. The library still does _a lot_ for us.

## Testing

The component is tested so that
- its `name` prop is used for the `input` element, and
- the `aria-invalid` and `aria-describedby` attributes are set correctly

However, moving the `label` and `input` elements for the data property into a separate component broke one of the tests contributed by @jeffnhorner: "that there are 3 labels in the LineChartSettings window". This was because the unit tests use a shallow mount.

I have replaced this test with three new tests that hopefully give us similar confidence: to check that the fields required to save line chart card settings are present on the form. The tests look for the `name` attribute (which the new component also has).

The tests for `pathIsValid` are mostly there to ensure somebody simplifying `messagePathEvaluation.js` doesn't cause the jmespath.js bug to bite us later.