### PR TITLE
Accessible color picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3631,11 +3631,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "clamp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
-      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
-    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -8197,11 +8192,6 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -8317,11 +8307,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
       "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-    },
-    "material-colors": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -11388,11 +11373,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
-    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -12011,17 +11991,6 @@
       "requires": {
         "a11y-dialog": "^5.2.0",
         "portal-vue": "^2.1.0"
-      }
-    },
-    "vue-color": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/vue-color/-/vue-color-2.7.0.tgz",
-      "integrity": "sha512-fak9oPRL3BsYtakTGmWIS2yNRppRYNlMgGGq78CMH34ipU8fLgi/bT9JiSPcscpdTNLGracuOFuZ8OFeml+SQQ==",
-      "requires": {
-        "clamp": "^1.0.1",
-        "lodash.throttle": "^4.0.0",
-        "material-colors": "^1.0.0",
-        "tinycolor2": "^1.1.2"
       }
     },
     "vue-hot-reload-api": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "socket.io": "^2.2.0",
     "vue": "^2.6.10",
     "vue-a11y-dialog": "^0.5.0",
-    "vue-color": "^2.7.0",
     "whatwg-fetch": "^3.0.0"
   },
   "engines": {

--- a/public/css/color-picker.css
+++ b/public/css/color-picker.css
@@ -1,0 +1,423 @@
+.cp-picker {
+  --cp-width: 300px;
+  --cp-spacing: 6px;
+  --cp-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica,
+    Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  --cp-text-color: #000;
+  --cp-background-color: #fff;
+  --cp-focus-color: dodgerblue;
+  --cp-box-shadow-focus: 0 0 0 2px var(--cp-focus-color);
+
+  --cp-color: hsl(var(--hsl-h), var(--hsl-s), var(--hsl-l), var(--hsl-a));
+
+  display: block;
+  width: var(--cp-width);
+  font-size: 12px;
+  font-family: var(--cp-font-family);
+  color: var(--cp-text-color);
+  background-color: var(--cp-background-color);
+}
+
+.cp-picker *,
+.cp-picker *::before,
+.cp-picker *::after {
+  box-sizing: border-box;
+}
+
+.cp-picker button {
+  font: inherit;
+}
+
+.cp-picker button:hover {
+  outline: none;
+  background-color: #ddd;
+}
+
+.cp-picker button::-moz-focus-inner {
+  padding: 0;
+  border-style: none;
+}
+
+.cp-color-space {
+  position: relative;
+  overflow: hidden;
+  height: calc(var(--cp-width) * 0.6);
+  background-color: hsl(var(--hsl-h), 100%, 50%);
+  background-image: linear-gradient(to top, #000, transparent),
+    linear-gradient(to right, #fff, hsla(0, 0%, 100%, 0));
+}
+
+.cp-color-space__marker {
+  --cp-marker-size: calc(var(--cp-spacing) * 4);
+
+  box-sizing: border-box;
+  position: absolute;
+  bottom: var(--hsv-v);
+  left: var(--hsv-s);
+  width: var(--cp-marker-size);
+  height: var(--cp-marker-size);
+  margin-left: calc(-1 * var(--cp-marker-size) / 2);
+  margin-bottom: calc(-1 * var(--cp-marker-size) / 2);
+  border: 3px solid #fff;
+  box-shadow: 0 0 0 1px #000;
+  border-radius: 50%;
+}
+
+.cp-color-space__marker:focus {
+  outline: none;
+  box-shadow: var(--cp-box-shadow-focus);
+}
+
+.cp-preview-row,
+.cp-color-format-row {
+  padding-top: var(--cp-spacing);
+  padding-bottom: var(--cp-spacing);
+}
+
+.cp-slider-group > *:not(:first-child) {
+  margin-top: calc(var(--cp-spacing) * 2);
+}
+
+.cp-slider {
+  --slider-track-width: 100%;
+  --slider-track-height: calc(var(--cp-spacing) * 3);
+  --slider-thumb-size: calc(var(--cp-spacing) * 4);
+
+  display: block;
+}
+
+.cp-slider__input,
+.cp-slider__input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+}
+
+.cp-slider__input {
+  display: block;
+  width: var(--slider-track-width);
+  height: var(--slider-track-height);
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+}
+
+.cp-slider__input:focus {
+  outline: none;
+}
+
+.cp-slider__input:focus::-moz-range-track {
+  outline: 2px solid var(--cp-focus-color);
+}
+
+.cp-slider__input:focus::-webkit-slider-runnable-track {
+  outline: 2px solid var(--cp-focus-color);
+}
+
+.cp-slider__input:focus::-ms-track {
+  outline: 2px solid var(--cp-focus-color);
+}
+
+/* Firefox, why?! */
+.cp-slider__input::-moz-focus-outer {
+  border: none;
+}
+
+/* Range input: Tracks */
+.cp-slider__input::-moz-range-track {
+  display: block;
+  box-sizing: border-box;
+  height: var(--slider-track-height);
+}
+
+.cp-slider__input--hue::-moz-range-track {
+  background-image: linear-gradient(
+    to right,
+    #f00 0,
+    /*   0° */ #ff0 16.67%,
+    /*  60° */ #0f0 33.33%,
+    /* 120° */ #0ff 50%,
+    /* 180° */ #00f 66.67%,
+    /* 240° */ #f0f 83.33%,
+    /* 300° */ #f00 /* 360° */
+  );
+}
+
+.cp-slider__input--alpha::-moz-range-track {
+  background-image: linear-gradient(to right, transparent, var(--cp-color));
+}
+
+.cp-slider__input::-webkit-slider-runnable-track {
+  width: var(--slider-track-width);
+  height: var(--slider-track-height);
+  border: none;
+}
+
+.cp-slider__input--hue::-webkit-slider-runnable-track {
+  background-image: linear-gradient(
+    to right,
+    #f00 0,
+    /*   0° */ #ff0 16.67%,
+    /*  60° */ #0f0 33.33%,
+    /* 120° */ #0ff 50%,
+    /* 180° */ #00f 66.67%,
+    /* 240° */ #f0f 83.33%,
+    /* 300° */ #f00 /* 360° */
+  );
+}
+
+.cp-slider__input--alpha::-webkit-slider-runnable-track {
+  background-image: linear-gradient(to right, transparent, var(--cp-color));
+}
+
+.cp-slider__input::-ms-track {
+  width: var(--slider-track-width);
+  height: var(--slider-track-height);
+  border: none;
+}
+
+.cp-slider__input--hue::-ms-track {
+  background-image: linear-gradient(
+    to right,
+    #f00 0,
+    /*   0° */ #ff0 16.67%,
+    /*  60° */ #0f0 33.33%,
+    /* 120° */ #0ff 50%,
+    /* 180° */ #00f 66.67%,
+    /* 240° */ #f0f 83.33%,
+    /* 300° */ #f00 /* 360° */
+  );
+}
+
+.cp-slider__input--alpha::-ms-track {
+  background-image: linear-gradient(to right, transparent, var(--cp-color));
+}
+
+/* Range input: Thumbs */
+.cp-slider__input::-moz-range-thumb {
+  box-sizing: border-box;
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  border: 3px solid #fff;
+  border-radius: 50%;
+  background-color: transparent;
+  box-shadow: 0 0 0 1px #000;
+  transform: rotate(0);
+}
+
+.cp-slider__input::-webkit-slider-thumb {
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  margin-top: calc((var(--slider-track-height) - var(--slider-thumb-size)) / 2);
+  border: 3px solid #fff;
+  border-radius: 50%;
+  background-color: transparent;
+  box-shadow: 0 0 0 1px #000;
+  transform: rotate(0);
+}
+
+.cp-slider__input::-ms-thumb {
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  margin-top: 0;
+  border: 3px solid #fff;
+  border-radius: 50%;
+  background-color: transparent;
+  box-shadow: 0 0 0 1px #000;
+  transform: rotate(0);
+}
+
+.cp-text-field {
+  display: block;
+}
+
+.cp-text-field__label {
+  display: block;
+  text-align: center;
+}
+
+.cp-text-field__input {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0.5em 0.25em;
+  border: 1px solid #ccc;
+  text-align: center;
+  font: inherit;
+  font-family: "Fira Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
+    Courier, monospace;
+}
+
+.cp-select {
+  display: block;
+}
+
+.cp-select__input {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+
+  margin: 0;
+  padding: 0.5em 0.8em 0.5em 0.25em;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23currentColor%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E");
+  background-repeat: no-repeat, repeat;
+  background-position: right 0.55em top 50%, 0 0;
+  background-size: 0.7em auto, 100%;
+  font: inherit;
+  line-height: 1;
+  height: 31px; /* ??? */
+  min-width: 5em;
+}
+
+/* What the fuck, Firefox */
+.cp-select__input:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.cp-select option {
+  padding: 0;
+}
+
+.cp-color-preview {
+  position: relative;
+  display: block;
+  width: calc(var(--cp-spacing) * 6);
+  height: calc(var(--cp-spacing) * 6);
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.cp-color-preview::before {
+  content: "";
+  position: absolute;
+  z-index: 10;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--cp-color);
+}
+
+.cp-copy-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--cp-spacing) * 6);
+  height: calc(var(--cp-spacing) * 6);
+  border: none;
+  border-radius: 50%;
+  background-color: #fff;
+}
+
+.cp-copy-button:focus {
+  outline: none;
+  box-shadow: var(--cp-box-shadow-focus);
+}
+
+.cp-clipboard-icon {
+  transform: rotate(0);
+}
+
+.cp-format-switcher-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--cp-spacing);
+  border: none;
+  background-color: #fff;
+}
+
+.cp-switcher-arrow-icon {
+  transform: rotate(0);
+}
+
+[data-cp-format-group="hsl"],
+[data-cp-format-group="hsv"],
+[data-cp-format-group="hwb"],
+[data-cp-format-group="rgb"],
+[data-cp-format-group="hex"] {
+  display: none;
+}
+
+.cp-picker[data-cp-active-format="hsl"] [data-cp-format-group="hsl"],
+.cp-picker[data-cp-active-format="hsv"] [data-cp-format-group="hsv"],
+.cp-picker[data-cp-active-format="hwb"] [data-cp-format-group="hwb"],
+.cp-picker[data-cp-active-format="rgb"] [data-cp-format-group="rgb"],
+.cp-picker[data-cp-active-format="hex"] [data-cp-format-group="hex"] {
+  display: block;
+}
+
+/*
+Utility: Tiled background
+*/
+.cp-tiled-background {
+  background-color: #fff;
+  background-image: linear-gradient(
+      45deg,
+      #eee 25%,
+      transparent 25%,
+      transparent 75%,
+      #eee 75%,
+      #eee
+    ),
+    linear-gradient(
+      45deg,
+      #eee 25%,
+      transparent 25%,
+      transparent 75%,
+      #eee 75%,
+      #eee
+    );
+  background-size: calc(var(--cp-spacing) * 2) calc(var(--cp-spacing) * 2);
+  background-position: 0 0, var(--cp-spacing) var(--cp-spacing);
+}
+
+/*
+Utility: Columns
+*/
+.cp-columns {
+  display: flex;
+  align-items: center;
+}
+
+.cp-columns--bottom {
+  align-items: flex-end;
+}
+
+.cp-columns--center {
+  justify-content: center;
+}
+
+.cp-column:not(:first-child) {
+  margin-left: var(--cp-spacing);
+}
+
+.cp-column--grow {
+  flex-grow: 1;
+}
+
+/*
+Utility: Visibility hidden
+
+Source: https://github.com/h5bp/html5-boilerplate
+
+Hide only visually, but have it available for screen readers:
+https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+
+1. For long content, line feeds are not interpreted as spaces
+   and small width causes content to wrap 1 word per line:
+   https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
+*/
+.cp-visually-hidden {
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  white-space: nowrap; /* 1. */
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -48,11 +48,10 @@ p {
 }
 
 form {
-  background-color: cyan;
+  background-color: papayawhip;
   padding: 15px;
   display: inline-block;
   width: 100%;
-  max-width: 340px;
   border-radius: 3px;
 }
 
@@ -69,6 +68,10 @@ textarea {
   border: 1px solid lightgrey;
   border-radius: 3px;
   font-size: 14px;
+}
+
+select {
+  border-radius: 3px;
 }
 
 li {
@@ -322,12 +325,16 @@ p.success {
   color: #048401;
 }
 
+.cardForm {
+  --card-form-width: 340px;
+}
+
 .cardForm form {
   padding: 0;
   background-color: white;
   display: inline-block;
   width: 100%;
-  max-width: 340px;
+  max-width: var(--card-form-width);
 }
 
 input {
@@ -428,7 +435,6 @@ select {
 }
 
 .settings select {
-  height: 30px;
   width: 100%;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,7 @@
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="/css/style.css" />
+    <link rel="stylesheet" href="/css/color-picker.css" />
   </head>
 
   <body>

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -207,8 +207,6 @@ export default {
      * @param {MouseEvent|TouchEvent} event
      */
     dragCard(event, clientX, clientY) {
-      event.stopPropagation();
-
       if (!this.draggingCard || this.editingCard) {
         return;
       }
@@ -322,7 +320,7 @@ export default {
       return {
         top: this.top,
         left: this.left,
-        width: `${this.blockSize[0] * this.tile.size[0]}px`,
+        minWidth: `${this.blockSize[0] * this.tile.size[0]}px`,
         minHeight: `${this.blockSize[1] * this.tile.size[1]}px`
       };
     },

--- a/public/js/components/ColorPicker.vue
+++ b/public/js/components/ColorPicker.vue
@@ -1,0 +1,804 @@
+<template>
+  <div class="cp-picker" :data-cp-active-format="activeFormat">
+    <div
+      ref="colorSpace"
+      class="cp-color-space"
+      @mousedown="pointerOriginatedInColorSpace = true"
+      @touchstart="pointerOriginatedInColorSpace = true"
+    >
+      <div
+        class="cp-color-space__marker"
+        data-cp-marker-controls-format="hsv"
+        data-cp-marker-x-controls-channel="s"
+        data-cp-marker-y-controls-channel="v"
+        tabindex="0"
+        aria-label="Marker"
+        @keydown="moveMarkerWithArrows"
+      ></div>
+    </div>
+
+    <div class="cp-columns cp-preview-row">
+      <div class="cp-slider-group cp-column cp-column--grow">
+        <label class="cp-slider" :for="`hue-slider-${uid}`">
+          <span class="cp-slider__label cp-visually-hidden">Hue</span>
+
+          <input
+            class="cp-slider__input cp-slider__input--hue"
+            :id="`hue-slider-${uid}`"
+            data-cp-input-hsl="h"
+            type="range"
+          />
+        </label>
+
+        <label class="cp-slider" :for="`alpha-slider-${uid}`">
+          <span class="cp-slider__label cp-visually-hidden">Alpha</span>
+
+          <input
+            class="cp-slider__input cp-slider__input--alpha cp-tiled-background"
+            :id="`alpha-slider-${uid}`"
+            data-cp-input-hsl="a"
+            type="range"
+          />
+        </label>
+      </div>
+
+      <div class="cp-color-preview cp-column cp-tiled-background"></div>
+
+      <div class="cp-column">
+        <button class="cp-copy-button" @click="copyColor">
+          <span class="cp-visually-hidden">Copy</span>
+
+          <svg
+            class="cp-clipboard-icon"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            width="15"
+            height="15"
+            viewBox="0 0 15 15"
+          >
+            <path
+              d="M5 0v2H1v13h12v-3h-1v2H2V5h10v3h1V2H9V0zm1 1h2v2h3v1H3V3h3z"
+            />
+            <path
+              d="M10 7v2h5v2h-5v2l-3-3zM3 6h5v1H3zm0 2h3v1H3zm0 2h3v1H3zm0 2h5v1H3z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div class="cp-color-format-row cp-columns cp-columns--bottom">
+      <div class="cp-column">
+        <label class="cp-select" :for="`cp-format-select-${uid}`">
+          <span class="cp-select__label cp-visually-hidden"
+            >Select color format</span
+          >
+
+          <select
+            class="cp-select__input"
+            :id="`cp-format-select-${uid}`"
+            :value="activeFormat"
+            @input="selectActiveFormat"
+          >
+            <option
+              v-for="format in supportedColorFormats"
+              :value="format"
+              :key="format"
+              >{{ format }}</option
+            >
+          </select>
+        </label>
+      </div>
+
+      <div class="cp-column cp-column--grow">
+        <div data-cp-format-group="hsl">
+          <div class="cp-columns cp-columns--center">
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hsl-h-${uid}`">
+                <span class="cp-text-field__label">H</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hsl-h-${uid}`"
+                  data-cp-input-hsl="h"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hsl-s-${uid}`">
+                <span class="cp-text-field__label">S</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hsl-s-${uid}`"
+                  data-cp-input-hsl="s"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hsl-l-${uid}`">
+                <span class="cp-text-field__label">L</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hsl-l-${uid}`"
+                  data-cp-input-hsl="l"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hsl-a-${uid}`">
+                <span class="cp-text-field__label">A</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hsl-a-${uid}`"
+                  data-cp-input-hsl="a"
+                  type="text"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div data-cp-format-group="hsv">
+          <div class="cp-columns cp-columns--center">
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hsv-h-${uid}`">
+                <span class="cp-text-field__label">H</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hsv-h-${uid}`"
+                  data-cp-input-hsv="h"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hsv-s-${uid}`">
+                <span class="cp-text-field__label">S</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hsv-s-${uid}`"
+                  data-cp-input-hsv="s"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hsv-v-${uid}`">
+                <span class="cp-text-field__label">V</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hsv-v-${uid}`"
+                  data-cp-input-hsv="v"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hsv-a-${uid}`">
+                <span class="cp-text-field__label">A</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hsv-a-${uid}`"
+                  data-cp-input-hsv="a"
+                  type="text"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div data-cp-format-group="hwb">
+          <div class="cp-columns cp-columns--center">
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hwb-h-${uid}`">
+                <span class="cp-text-field__label">H</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hwb-h-${uid}`"
+                  data-cp-input-hwb="h"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hwb-w-${uid}`">
+                <span class="cp-text-field__label">W</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hwb-w-${uid}`"
+                  data-cp-input-hwb="w"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hwb-b-${uid}`">
+                <span class="cp-text-field__label">B</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hwb-b-${uid}`"
+                  data-cp-input-hwb="b"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hwb-a-${uid}`">
+                <span class="cp-text-field__label">A</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hwb-a-${uid}`"
+                  data-cp-input-hwb="a"
+                  type="text"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div data-cp-format-group="rgb">
+          <div class="cp-columns cp-columns--center">
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-rgb-r-${uid}`">
+                <span class="cp-text-field__label">R</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-rgb-r-${uid}`"
+                  data-cp-input-rgb="r"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-rgb-g-${uid}`">
+                <span class="cp-text-field__label">G</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-rgb-g-${uid}`"
+                  data-cp-input-rgb="g"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-rgb-b-${uid}`">
+                <span class="cp-text-field__label">B</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-rgb-b-${uid}`"
+                  data-cp-input-rgb="b"
+                  type="text"
+                />
+              </label>
+            </div>
+
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-rgb-a-${uid}`">
+                <span class="cp-text-field__label">A</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-rgb-a-${uid}`"
+                  data-cp-input-rgb="a"
+                  type="text"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div data-cp-format-group="hex">
+          <div class="cp-columns cp-columns--center">
+            <div class="cp-column cp-column--grow">
+              <label class="cp-text-field" :for="`color-hex-${uid}`">
+                <span class="cp-text-field__label">Hexadecimal</span>
+                <input
+                  class="cp-text-field__input"
+                  :id="`color-hex-${uid}`"
+                  data-cp-input-hex
+                  type="text"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import copyToClipboard from "../lib/copyToClipboard.js";
+import {
+  HslColor,
+  HsvColor,
+  HwbColor,
+  RgbColor,
+  HexColor
+} from "../lib/colorFormats.js";
+import convert from "../lib/colorConversions.js";
+
+export default {
+  name: "ColorPicker",
+  props: ["uid", "color", "format"],
+
+  data() {
+    return {
+      activeFormat: "rgb",
+      colors: {
+        hsl: {},
+        hsv: {},
+        hwb: {},
+        rgb: {},
+        hex: ""
+      }
+    };
+  },
+
+  created() {
+    this.supportedColorFormats = ["hsl", "hsv", "hwb", "rgb", "hex"];
+
+    // This map holds data relevant for color input fields.
+    this.colorInputs = new Map()
+      .set("hsl", new HslColor())
+      .set("hsv", new HsvColor())
+      .set("hwb", new HwbColor())
+      .set("rgb", new RgbColor())
+      .set("hex", new HexColor());
+  },
+
+  mounted() {
+    this.initColorInputs();
+    this.trackPointerOrigin();
+    this.initMarkerPointerNav();
+    this.enhanceRangeInputs();
+
+    document.head.style.color = this.color;
+    const rgbValue = getComputedStyle(document.head).color;
+    const functionArgument = rgbValue
+      .substring(rgbValue.indexOf("(") + 1, rgbValue.indexOf(")"))
+      .replace(" ", "");
+    const channelValues = functionArgument.split(",");
+    const rgb = {
+      r: channelValues[0] / 255,
+      g: channelValues[1] / 255,
+      b: channelValues[2] / 255,
+      a: channelValues.length === 4 ? channelValues[3] : 1
+    };
+
+    this.setColorValue(rgb, "rgb");
+  },
+
+  methods: {
+    /**
+     * Sets the active color format. If the format is not support, a valid default value will be set
+     * instead.
+     *
+     * @param {string} format
+     */
+    setActiveFormat(format) {
+      if (this.supportedColorFormats.includes(format)) {
+        this.activeFormat = format;
+      } else {
+        this.activeFormat = "hsl";
+      }
+    },
+
+    getColorValue(format, channel = undefined) {
+      if (channel === undefined) {
+        return this.colors[format];
+      }
+
+      return this.colors[format][channel];
+    },
+
+    setColorValue(value, format, channel = undefined) {
+      if (channel === undefined) {
+        this.colors[format] = value;
+      } else {
+        this.colors[format][channel] = value;
+      }
+
+      this.updateColors(format);
+      this.emitColorInputEvent();
+    },
+
+    /**
+     * Initializes all color inputs and their respective DOM nodes.
+     *
+     * - Registers event listeners to react to color changes in input fields.
+     * - Sets the input’s color format (e.g. HSL) and channel (e.g. “s” for saturation).
+     * - Sets additional input attributes (e.g. `min`, `max`, and `step` for range/number inputs).
+     */
+    initColorInputs() {
+      for (const colorInput of this.colorInputs.values()) {
+        this.initColorInput(colorInput);
+
+        if (colorInput.channelInputs.size > 0) {
+          for (const channel of colorInput.channelInputs.values()) {
+            this.initChannel(channel, colorInput.format);
+          }
+        }
+      }
+    },
+
+    initColorInput(colorInput) {
+      if (colorInput.nodes === undefined) {
+        colorInput.nodes = [];
+      }
+
+      // Store references to all used color inputs
+      const selector = `[data-cp-input-${colorInput.format}=""]`;
+      const colorInputNodes = this.$el.querySelectorAll(selector);
+      colorInputNodes.forEach(colorInputNode => {
+        colorInput.nodes.push(colorInputNode);
+      });
+
+      for (const inputNode of colorInput.nodes) {
+        inputNode.addEventListener(
+          "change",
+          this.handleColorInputChange.bind(this)
+        );
+
+        if (colorInput.format !== undefined) {
+          inputNode.setAttribute("data-cp-color-format", colorInput.format);
+        }
+      }
+    },
+
+    initChannel(channel, colorFormat) {
+      if (channel.nodes === undefined) {
+        channel.nodes = [];
+      }
+
+      // Store references to all used color channel inputs
+      const selector = `[data-cp-input-${colorFormat}="${channel.name}"]`;
+      const channelNodes = this.$el.querySelectorAll(selector);
+      channelNodes.forEach(channelNode => {
+        channel.nodes.push(channelNode);
+      });
+
+      for (const channelNode of channel.nodes) {
+        const eventType = channelNode.type === "range" ? "input" : "change";
+        channelNode.addEventListener(
+          eventType,
+          this.handleColorInputChange.bind(this)
+        );
+
+        if (colorFormat !== undefined) {
+          channelNode.setAttribute("data-cp-color-format", colorFormat);
+        }
+
+        channelNode.setAttribute("data-cp-color-channel", channel.name);
+
+        if (channelNode.type === "range" || channelNode.type === "number") {
+          channelNode.setAttribute("min", channel.min);
+          channelNode.setAttribute("max", channel.max);
+          channelNode.setAttribute("step", channel.step);
+        }
+      }
+    },
+
+    /**
+     * Generic event handler for updating the internal color data when the value of a color input
+     * changes.
+     *
+     * For example, if the value in the input for an HSL color’s saturation channel changes, the
+     * appropriate color will be updated and all colors of other color formats will be
+     * re-calculated.
+     *
+     * @param {Event} event
+     */
+    handleColorInputChange(event) {
+      const inputNode = event.currentTarget;
+
+      if (!(inputNode instanceof HTMLInputElement)) {
+        return;
+      }
+
+      const colorFormat = inputNode.getAttribute("data-cp-color-format");
+      const colorInput = this.colorInputs.get(colorFormat);
+
+      const channelName = inputNode.getAttribute("data-cp-color-channel");
+
+      if (channelName !== null) {
+        const channel = colorInput.channelInputs.get(channelName);
+        const value = channel.convertToNumber(inputNode.value);
+
+        if (isNaN(value)) {
+          return;
+        }
+
+        this.setColorValue(value, colorFormat, channelName);
+      } else {
+        this.setColorValue(inputNode.value, colorFormat);
+      }
+    },
+
+    /**
+     * Updates all color inputs if their underlying color data changed.
+     */
+    updateColorInputs() {
+      for (const colorInput of this.colorInputs.values()) {
+        this.updateColorInput(colorInput);
+
+        if (colorInput.channelInputs.size > 0) {
+          for (const channelInput of colorInput.channelInputs.values()) {
+            this.updateChannelInput(channelInput, colorInput.format);
+          }
+        }
+      }
+    },
+
+    updateColorInput(colorInput) {
+      const color = this.getColorValue(colorInput.format);
+
+      for (const colorInputNode of colorInput.nodes) {
+        colorInputNode.value = color;
+        this.$el.style.setProperty(`--${colorInput.format}`, color);
+      }
+    },
+
+    updateChannelInput(channel, colorFormat) {
+      const color = this.getColorValue(colorFormat);
+      const newValue = channel.convertToCssValue(color[channel.name]);
+
+      for (const inputNode of channel.nodes) {
+        if (inputNode.value !== newValue) {
+          inputNode.value = newValue;
+        }
+      }
+
+      this.$el.style.setProperty(`--${colorFormat}-${channel.name}`, newValue);
+    },
+
+    /**
+     * @param {string} sourceFormat
+     */
+    updateColors(sourceFormat) {
+      this.cascadeColorChanges(sourceFormat);
+      this.updateColorInputs();
+    },
+
+    /**
+     * Re-calculates all colors based on a changed color.
+     *
+     * For example, if an HSL color was changed, this method re-calculates the RGB, HSV, etc.
+     * colors.
+     *
+     * @param {string} sourceFormat
+     */
+    cascadeColorChanges(sourceFormat) {
+      const sourceColor = this.getColorValue(sourceFormat);
+      const targetFormats = this.supportedColorFormats.filter(
+        format => format !== sourceFormat
+      );
+
+      for (const targetFormat of targetFormats) {
+        const color = convert[sourceFormat][targetFormat](sourceColor);
+        this.colors[targetFormat] = color;
+      }
+    },
+
+    /**
+     * Emits a custom `cpInput` event with the following data in the `details` property:
+     *
+     * - format: The active color format (i.e. colorPicker.activeFormat)
+     * - rawValue: The raw color value as it’s represented internally
+     * - cssValue: A CSS color value matching the active color format (e.g. hsla(270, 80%, 50%, 1))
+     *
+     * This event is fired for every change to the internal color data.
+     */
+    emitColorInputEvent() {
+      const colorInput = this.colorInputs.get(this.activeFormat);
+      const rawValue = this.getColorValue(this.activeFormat);
+      const cssValue = colorInput.convertToCssColor(rawValue);
+
+      this.$emit("change", cssValue);
+    },
+
+    trackPointerOrigin() {
+      if (this.$refs.colorSpace === null) {
+        return;
+      }
+
+      this.pointerOriginatedInColorSpace = false;
+
+      document.addEventListener("mouseup", () => {
+        this.pointerOriginatedInColorSpace = false;
+      });
+
+      document.addEventListener("touchend", () => {
+        this.pointerOriginatedInColorSpace = false;
+      });
+    },
+
+    initMarkerPointerNav() {
+      if (this.$refs.colorSpace !== null) {
+        document.addEventListener("mousemove", this.moveMarkerWithMouse, {
+          passive: false
+        });
+        document.addEventListener("touchmove", this.moveMarkerWithTouch, {
+          passive: false
+        });
+      }
+    },
+
+    /**
+     * @param {MouseEvent} event
+     */
+    moveMarkerWithMouse(event) {
+      if (event.buttons !== 1 || this.pointerOriginatedInColorSpace === false) {
+        return;
+      }
+
+      this.moveMarker(event.clientX, event.clientY);
+    },
+
+    /**
+     * @param {TouchEvent} event
+     */
+    moveMarkerWithTouch(event) {
+      if (this.pointerOriginatedInColorSpace === false) {
+        return;
+      }
+
+      this.moveMarker(event.touches[0].clientX, event.touches[0].clientY);
+    },
+
+    /**
+     * @param {number} clientX
+     * @param {number} clientY
+     */
+    moveMarker(clientX, clientY) {
+      // Stop touch events from dragging the page.
+      event.preventDefault();
+
+      const rect = this.$refs.colorSpace.getBoundingClientRect();
+      const x = clientX - rect.left;
+      const y = clientY - rect.top;
+
+      const newHsvS = clamp(x / rect.width, 0, 1);
+      const newHsvV = clamp(1 - y / rect.height, 0, 1);
+
+      this.setColorValue(newHsvS, "hsv", "s");
+      this.setColorValue(newHsvV, "hsv", "v");
+    },
+
+    /**
+     * Controls the saturation and value portions of the color in HSV representation.
+     *
+     * @param {KeyboardEvent} event
+     */
+    moveMarkerWithArrows(event) {
+      const marker = event.currentTarget;
+
+      if (
+        !["ArrowUp", "ArrowRight", "ArrowDown", "ArrowLeft"].includes(
+          event.key
+        ) ||
+        !(marker instanceof HTMLElement)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const format = marker.getAttribute("data-cp-marker-controls-format");
+      const xAxisChannel = marker.getAttribute(
+        "data-cp-marker-x-controls-channel"
+      );
+      const yAxisChannel = marker.getAttribute(
+        "data-cp-marker-y-controls-channel"
+      );
+      const direction = ["ArrowLeft", "ArrowDown"].includes(event.key) ? -1 : 1;
+      const channel = ["ArrowLeft", "ArrowRight"].includes(event.key)
+        ? xAxisChannel
+        : yAxisChannel;
+      const step = event.shiftKey ? 10 : 1;
+
+      const newValue =
+        this.getColorValue(format, channel) + direction * step * 0.01;
+      this.setColorValue(clamp(newValue, 0, 1), format, channel);
+    },
+
+    /**
+     * Copies the current color (determined by the active color format).
+     *
+     * For example, if the active color format is HSL, the copied text will be a valid CSS color in
+     * HSL format.
+     */
+    copyColor() {
+      const colorInput = this.colorInputs.get(this.activeFormat);
+      const color = this.getColorValue(colorInput.format);
+      const colorString = colorInput.convertToCssColor(color);
+      copyToClipboard(colorString);
+    },
+
+    /**
+     * Cycles through the active color formats.
+     */
+    selectActiveFormat(event) {
+      const newFormat = event.target.value;
+      if (this.supportedColorFormats.includes(newFormat)) {
+        this.activeFormat = newFormat;
+      }
+    },
+
+    /**
+     * Enhances the keyboard interaction with all range inputs on a page by adding the ability to
+     * increment/decrement an input’s value in greater steps when holding down the shift key.
+     *
+     * In its initial state, a factor of 10 will be applied to all steps.
+     */
+    enhanceRangeInputs() {
+      const inputs = this.$el.querySelectorAll('input[type="range"]');
+      inputs.forEach(input => {
+        input.addEventListener("keydown", this.changeInputValue, {
+          passive: true
+        });
+      });
+    },
+
+    /**
+     * This event listener adds the ability to navigate
+     * a range input in larger steps by holding down Shift
+     * while pressing the arrow keys.
+     *
+     * @param {KeyboardEvent} event
+     */
+    changeInputValue(event) {
+      const input = event.currentTarget;
+
+      if (
+        !["ArrowUp", "ArrowRight", "ArrowDown", "ArrowLeft"].includes(
+          event.key
+        ) ||
+        !event.shiftKey ||
+        !(input instanceof HTMLInputElement && input.type === "range")
+      ) {
+        return;
+      }
+
+      const step = input.step !== "" ? parseFloat(input.step) : 1;
+      const stepFactor = 10;
+      const direction = ["ArrowLeft", "ArrowDown"].includes(event.key) ? -1 : 1;
+      const wideStep = step * stepFactor;
+      const value = parseFloat(input.value) + direction * wideStep;
+      const min = input.min !== "" ? parseFloat(input.min) : 0;
+      const max = input.max !== "" ? parseFloat(input.max) : 100;
+      const newValue = clamp(value, min, max);
+
+      // Remove one step because the default action needs to be able to set a new value for it to fire
+      // events, too.
+      input.value = String(newValue - direction * step);
+    }
+  }
+};
+
+/**
+ * Clamps the given value between the min and max boundaries.
+ *
+ * @param {number} value
+ * @param {number} min
+ * @param {number} max
+ * @returns {number} - `value` if `min <= value <= max`
+ *                   - `min` if `value < min`
+ *                   - `max` if `value > max`
+ */
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(value, max));
+}
+</script>

--- a/public/js/components/DashboardSettings.vue
+++ b/public/js/components/DashboardSettings.vue
@@ -15,6 +15,7 @@
             settingsPanelOpen ? "Close settings panel" : "Open settings panel"
           }}
         </span>
+
         <span aria-hidden="true">
           {{ settingsPanelOpen ? "&rarr;" : "⚙️" }}
         </span>
@@ -25,27 +26,52 @@
 
     <div class="settings__body">
       <form v-on:submit.prevent="onSaveSettings">
-        <label>
+        <label for="dashboard-settings-title">
           App Title
-          <input type="text" name="title" :value="dashboard.title" />
+          <input
+            type="text"
+            id="title"
+            name="dashboard-settings-title"
+            :value="dashboard.title"
+          />
         </label>
 
-        <label>
+        <label for="dashboard-settings-bgColor">
           Background Color
-          <compact-picker :value="bgColor" @input="updateValue" />
-          <input type="text" name="bgColor" v-model="bgColor" />
+          <input
+            type="hidden"
+            id="dashboard-settings-bgColor"
+            name="bgColor"
+            v-model="bgColor"
+          />
         </label>
 
-        <label>
+        <color-picker
+          :uid="'dashboard-settings'"
+          :color="bgColor"
+          @change="updateValue"
+          style="--cp-background-color: transparent; --cp-focus-color: var(--focus-color)"
+        />
+
+        <label for="dashboard-settings-bgImageUrl">
           Background Image URL
-          <input type="text" name="bgImageUrl" :value="dashboard.bgImageUrl" />
+          <input
+            type="text"
+            id="dashboard-settings-bgImageUrl"
+            name="bgImageUrl"
+            :value="dashboard.bgImageUrl"
+          />
         </label>
 
-        <label class="settings__checkbox-label">
+        <label
+          class="settings__checkbox-label"
+          for="dashboard-settings-bgImageRepeat"
+        >
           <span>Repeat background image?</span>
           <input
             class="settings__checkbox"
             type="checkbox"
+            id="dashboard-settings-bgImageRepeat"
             name="bgImageRepeat"
             :value="dashboard.bgImageRepeat"
             v-model="dashboard.bgImageRepeat"
@@ -58,9 +84,9 @@
       <h3>New Card</h3>
 
       <form v-on:submit.prevent="onCreateCard">
-        <label>
+        <label for="dashboard-settings-type">
           Card Type
-          <select name="type">
+          <select id="dashboard-settings-type" name="type">
             <option value="button">button</option>
             <option value="lineChart">line chart</option>
             <option value="number">number</option>
@@ -76,7 +102,7 @@
 </template>
 
 <script>
-import { Compact } from "vue-color";
+import ColorPicker from "./ColorPicker";
 import { saveDashboard } from "../lib/configuration.js";
 import templates from "../lib/templates.js";
 import createGuid from "../lib/guid.js";
@@ -84,15 +110,15 @@ import createGuid from "../lib/guid.js";
 export default {
   name: "dashboard-settings",
   props: ["dashboard"],
+  components: {
+    ColorPicker
+  },
   data() {
     return {
       status: "",
       settingsPanelOpen: true,
       bgColor: this.dashboard.bgColor
     };
-  },
-  components: {
-    "compact-picker": Compact
   },
   methods: {
     onSaveSettings: function(event) {
@@ -116,7 +142,7 @@ export default {
       this.settingsPanelOpen = this.settingsPanelOpen === true ? false : true;
     },
     updateValue(value) {
-      this.bgColor = value.hex;
+      this.bgColor = value;
     }
   }
 };

--- a/public/js/components/LineChartSettings.vue
+++ b/public/js/components/LineChartSettings.vue
@@ -1,15 +1,14 @@
 <template>
   <div>
-    <label>
+    <label :for="`deviceId-${tile.id}`">
       Device Id
-      <select name="deviceId" id="deviceSelect">
+      <select name="deviceId" :id="`deviceId-${tile.id}`">
         <option
           v-for="(device, index) in deviceList"
           :selected="device === tile.deviceId"
-          v-bind:key="`device-list-${index}`"
+          :key="`device-list-${index}`"
+          >{{ device }}</option
         >
-          {{ device }}
-        </option>
       </select>
     </label>
 
@@ -19,19 +18,47 @@
       v-bind:tileId="tile.id"
     />
 
-    <label>
+    <label :for="`lineColor-${tile.id}`">
       Line Color
-      <input type="text" name="lineColor" :value="tile.lineColor" />
+      <input
+        type="hidden"
+        :id="`lineColor-${tile.id}`"
+        name="lineColor"
+        v-model="lineColor"
+      />
     </label>
+
+    <color-picker
+      :uid="tile.id"
+      :color="lineColor"
+      @change="updateValue"
+      style="--cp-background-color: transparent; --cp-focus-color: var(--focus-color); --cp-width: var(--card-form-width)"
+    />
   </div>
 </template>
 
 <script>
+import ColorPicker from "./ColorPicker";
 import DataPropertyField from "./DataPropertyField";
 
 export default {
   name: "line-chart-settings",
-  components: { DataPropertyField },
-  props: ["tile", "deviceList"]
+  components: {
+    ColorPicker,
+    DataPropertyField
+  },
+  props: ["tile", "deviceList"],
+
+  data() {
+    return {
+      lineColor: this.tile.lineColor
+    };
+  },
+
+  methods: {
+    updateValue(value) {
+      this.lineColor = value;
+    }
+  }
 };
 </script>

--- a/public/js/components/NumberSettings.vue
+++ b/public/js/components/NumberSettings.vue
@@ -1,11 +1,12 @@
 <template>
   <div>
-    <label>
+    <label :for="`deviceId-${tile.id}`">
       Device Id
-      <select name="deviceId" id="deviceSelect">
+      <select name="deviceId" :id="`deviceId-${tile.id}`">
         <option
-          v-for="device in deviceList"
-          v-bind:selected="device === tile.deviceId"
+          v-for="(device, index) in deviceList"
+          :selected="device === tile.deviceId"
+          :key="`device-list-${index}`"
         >
           {{ device }}
         </option>
@@ -18,19 +19,47 @@
       v-bind:tileId="tile.id"
     />
 
-    <label>
+    <label :for="`textColor-${tile.id}`">
       Text Color
-      <input type="text" name="textColor" v-bind:value="tile.textColor" />
+      <input
+        type="hidden"
+        :id="`textColor-${tile.id}`"
+        name="textColor"
+        v-model="textColor"
+      />
     </label>
+
+    <color-picker
+      :uid="tile.id"
+      :color="textColor"
+      @change="updateValue"
+      style="--cp-background-color: transparent; --cp-focus-color: var(--focus-color); --cp-width: var(--card-form-width)"
+    />
   </div>
 </template>
 
 <script>
+import ColorPicker from "./ColorPicker";
 import DataPropertyField from "./DataPropertyField";
 
 export default {
   name: "number-settings",
-  components: { DataPropertyField },
-  props: ["tile", "deviceList"]
+  props: ["tile", "deviceList"],
+  components: {
+    ColorPicker,
+    DataPropertyField
+  },
+
+  data() {
+    return {
+      textColor: this.tile.textColor
+    };
+  },
+
+  methods: {
+    updateValue(value) {
+      this.textColor = value;
+    }
+  }
 };
 </script>

--- a/public/js/lib/colorConversions.js
+++ b/public/js/lib/colorConversions.js
@@ -1,0 +1,365 @@
+export default {
+  hsl: {
+    hsv: convertHslToHsv,
+    hwb: convertHslToHwb,
+    rgb: convertHslToRgb,
+    hex: convertHslToHex
+  },
+  hsv: {
+    hsl: convertHsvToHsl,
+    hwb: convertHsvToHwb,
+    rgb: convertHsvToRgb,
+    hex: convertHsvToHex
+  },
+  hwb: {
+    hsl: convertHwbToHsl,
+    hsv: convertHwbToHsv,
+    rgb: convertHwbToRgb,
+    hex: convertHwbToHex
+  },
+  rgb: {
+    hsl: convertRgbToHsl,
+    hsv: convertRgbToHsv,
+    hwb: convertRgbToHwb,
+    hex: convertRgbToHex
+  },
+  hex: {
+    hsl: convertHexToHsl,
+    hsv: convertHexToHsv,
+    hwb: convertHexToHwb,
+    rgb: convertHexToRgb
+  }
+};
+
+/**
+ * Converts an HSL color object to an HSV color object.
+ *
+ * Source: https://en.m.wikipedia.org/wiki/HSL_and_HSV#HSL_to_HSV
+ *
+ * @param {object} hsl
+ * @returns {object}
+ */
+function convertHslToHsv(hsl) {
+  const v = hsl.l + hsl.s * Math.min(hsl.l, 1 - hsl.l);
+  const s = v === 0 ? 0 : 2 - (2 * hsl.l) / v;
+
+  return {
+    h: hsl.h,
+    s,
+    v,
+    a: hsl.a
+  };
+}
+
+/**
+ * Converts an HSV color object to an HSL color object.
+ *
+ * Source: https://en.m.wikipedia.org/wiki/HSL_and_HSV#HSV_to_HSL
+ *
+ * @param {object} hsv
+ * @returns {object}
+ */
+function convertHsvToHsl(hsv) {
+  const l = hsv.v - (hsv.v * hsv.s) / 2;
+  const lMin = Math.min(l, 1 - l);
+  const s = lMin === 0 ? 0 : (hsv.v - l) / lMin;
+
+  return {
+    h: hsv.h,
+    s,
+    l,
+    a: hsv.a
+  };
+}
+
+/**
+ * @param {object} hwb
+ * @returns {object}
+ */
+function convertHwbToRgb(hwb) {
+  const hsv = convertHwbToHsv(hwb);
+  return convertHsvToRgb(hsv);
+}
+
+/**
+ * @param {object} rgb
+ * @returns {object}
+ */
+function convertRgbToHwb(rgb) {
+  const hsv = convertRgbToHsv(rgb);
+  return convertHsvToHwb(hsv);
+}
+
+/**
+ * @param {object} hwb
+ * @returns {object}
+ */
+function convertHwbToHsl(hwb) {
+  const hsv = convertHwbToHsv(hwb);
+  return convertHsvToHsl(hsv);
+}
+
+/**
+ * @param {object} hsl
+ * @returns {object}
+ */
+function convertHslToHwb(hsl) {
+  const hsv = convertHslToHsv(hsl);
+  return convertHsvToHwb(hsv);
+}
+
+/**
+ * @param {object} hsv
+ * @returns {object}
+ */
+function convertHsvToHwb(hsv) {
+  return {
+    h: hsv.h,
+    w: (1 - hsv.s) * hsv.v,
+    b: 1 - hsv.v,
+    a: hsv.a
+  };
+}
+
+/**
+ * @param {object} hwb
+ * @returns {object}
+ */
+function convertHwbToHsv(hwb) {
+  return {
+    h: hwb.h,
+    s: 1 - hwb.w / (1 - hwb.b),
+    v: 1 - hwb.b,
+    a: hwb.a
+  };
+}
+
+/**
+ * Source: https://en.m.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB
+ *
+ * @param {object} hsl
+ * @returns {object}
+ */
+function convertHslToRgb(hsl) {
+  const chroma = (1 - Math.abs(2 * hsl.l - 1)) * hsl.s;
+  const k = hsl.h / 60;
+  const x = chroma * (1 - Math.abs((k % 2) - 1));
+
+  let r_ = 0,
+    g_ = 0,
+    b_ = 0;
+  if (0 <= k && k <= 1) {
+    r_ = chroma;
+    g_ = x;
+  } else if (1 < k && k <= 2) {
+    r_ = x;
+    g_ = chroma;
+  } else if (2 < k && k <= 3) {
+    g_ = chroma;
+    b_ = x;
+  } else if (3 < k && k <= 4) {
+    g_ = x;
+    b_ = chroma;
+  } else if (4 < k && k <= 5) {
+    r_ = x;
+    b_ = chroma;
+  } else if (5 < k && k <= 6) {
+    r_ = chroma;
+    b_ = x;
+  }
+
+  const m = hsl.l - chroma / 2;
+  return {
+    r: r_ + m,
+    g: g_ + m,
+    b: b_ + m,
+    a: hsl.a
+  };
+}
+
+/**
+ * Source: https://en.m.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB
+ *
+ * @param {object} hsv
+ * @returns {object}
+ */
+function convertHsvToRgb(hsv) {
+  const chroma = hsv.v * hsv.s;
+  const k = hsv.h / 60;
+  const x = chroma * (1 - Math.abs((k % 2) - 1));
+
+  let r_ = 0,
+    g_ = 0,
+    b_ = 0;
+  if (0 <= k && k <= 1) {
+    r_ = chroma;
+    g_ = x;
+  } else if (1 < k && k <= 2) {
+    r_ = x;
+    g_ = chroma;
+  } else if (2 < k && k <= 3) {
+    g_ = chroma;
+    b_ = x;
+  } else if (3 < k && k <= 4) {
+    g_ = x;
+    b_ = chroma;
+  } else if (4 < k && k <= 5) {
+    r_ = x;
+    b_ = chroma;
+  } else if (5 < k && k <= 6) {
+    r_ = chroma;
+    b_ = x;
+  }
+
+  const m = hsv.v - chroma;
+  return {
+    r: r_ + m,
+    g: g_ + m,
+    b: b_ + m,
+    a: hsv.a
+  };
+}
+
+/**
+ * Source: https://en.m.wikipedia.org/wiki/HSL_and_HSV#RGB_to_HSL_and_HSV
+ *
+ * @param {object} rgb
+ * @returns {object}
+ */
+function convertRgbToHsl(rgb) {
+  const min = Math.min(rgb.r, Math.min(rgb.g, rgb.b));
+  const max = Math.max(rgb.r, Math.max(rgb.g, rgb.b));
+
+  let h;
+  if (max === min) {
+    h = 0;
+  } else if (max === rgb.r) {
+    h = 60 * (0 + (rgb.g - rgb.b) / (max - min));
+  } else if (max === rgb.g) {
+    h = 60 * (2 + (rgb.b - rgb.r) / (max - min));
+  } else if (max === rgb.b) {
+    h = 60 * (4 + (rgb.r - rgb.g) / (max - min));
+  }
+
+  if (h < 0) {
+    h += 360;
+  }
+
+  const l = (max + min) / 2;
+
+  let s;
+  if (max === 0 || min === 1) {
+    s = 0;
+  } else {
+    s = (max - l) / Math.min(l, 1 - l);
+  }
+
+  return {
+    h,
+    s,
+    l,
+    a: rgb.a
+  };
+}
+
+/**
+ * Source: https://en.m.wikipedia.org/wiki/HSL_and_HSV#RGB_to_HSL_and_HSV
+ *
+ * @param {object} rgb
+ * @returns {object}
+ */
+function convertRgbToHsv(rgb) {
+  const min = Math.min(rgb.r, Math.min(rgb.g, rgb.b));
+  const max = Math.max(rgb.r, Math.max(rgb.g, rgb.b));
+
+  let h;
+  if (max === min) {
+    h = 0;
+  } else if (max === rgb.r) {
+    h = 60 * (0 + (rgb.g - rgb.b) / (max - min));
+  } else if (max === rgb.g) {
+    h = 60 * (2 + (rgb.b - rgb.r) / (max - min));
+  } else if (max === rgb.b) {
+    h = 60 * (4 + (rgb.r - rgb.g) / (max - min));
+  }
+
+  if (h < 0) {
+    h += 360;
+  }
+
+  let s;
+  if (max === 0) {
+    s = 0;
+  } else {
+    s = (max - min) / max;
+  }
+
+  const v = max;
+
+  return {
+    h,
+    s,
+    v,
+    a: rgb.a
+  };
+}
+
+function convertRgbToHex(rgb) {
+  const hexChannels = Object.values(rgb).map(channel => {
+    const int = channel * 255;
+    let hex = Math.round(int).toString(16);
+    return hex.length === 1 ? "0" + hex : hex;
+  });
+
+  return "#" + hexChannels.join("");
+}
+
+function convertHexToRgb(hex) {
+  const rgbChannels = hex
+    .replace(/^#/, "")
+    .match(/.{2}/g)
+    .map(channel => {
+      return parseInt(channel, 16) / 255;
+    });
+
+  // if (rgbChannels.length === 3) {
+  //   rgbChannels.push(1);
+  // }
+
+  return {
+    r: rgbChannels[0],
+    g: rgbChannels[1],
+    b: rgbChannels[2],
+    a: rgbChannels[3]
+  };
+}
+
+function convertHslToHex(hsl) {
+  const rgb = convertHslToRgb(hsl);
+  return convertRgbToHex(rgb);
+}
+
+function convertHsvToHex(hsv) {
+  const rgb = convertHsvToRgb(hsv);
+  return convertRgbToHex(rgb);
+}
+
+function convertHwbToHex(hwb) {
+  const rgb = convertHwbToRgb(hwb);
+  return convertRgbToHex(rgb);
+}
+
+function convertHexToHsl(hex) {
+  const rgb = convertHexToRgb(hex);
+  return convertRgbToHsl(rgb);
+}
+
+function convertHexToHsv(hex) {
+  const rgb = convertHexToRgb(hex);
+  return convertRgbToHsv(rgb);
+}
+
+function convertHexToHwb(hex) {
+  const rgb = convertHexToRgb(hex);
+  return convertRgbToHwb(rgb);
+}

--- a/public/js/lib/colorFormats.js
+++ b/public/js/lib/colorFormats.js
@@ -1,0 +1,296 @@
+class Color {
+  constructor(format) {
+    this._format = format;
+    this._channelInputs = new Map();
+  }
+
+  get format() {
+    return this._format;
+  }
+
+  get channelInputs() {
+    return this._channelInputs;
+  }
+}
+
+class HslColor extends Color {
+  constructor() {
+    super("hsl");
+
+    this._channelInputs
+      .set("h", new CssHueAngle("h"))
+      .set("s", new CssPercentage("s"))
+      .set("l", new CssPercentage("l"))
+      .set("a", new CssAlphaChannel("a"));
+  }
+
+  convertToCssColor(value) {
+    return convertHslToCssColor(this, value);
+  }
+}
+
+class HsvColor extends Color {
+  constructor() {
+    super("hsv");
+
+    this._channelInputs
+      .set("h", new CssHueAngle("h"))
+      .set("s", new CssPercentage("s"))
+      .set("v", new CssPercentage("v"))
+      .set("a", new CssAlphaChannel("a"));
+  }
+
+  convertToCssColor(value) {
+    return convertHsvToCssColor(this, value);
+  }
+}
+
+class HwbColor extends Color {
+  constructor() {
+    super("hwb");
+
+    this._channelInputs
+      .set("h", new CssHueAngle("h"))
+      .set("w", new CssPercentage("w"))
+      .set("b", new CssPercentage("b"))
+      .set("a", new CssAlphaChannel("a"));
+  }
+
+  convertToCssColor(value) {
+    return convertHwbToCssColor(this, value);
+  }
+}
+
+class RgbColor extends Color {
+  constructor() {
+    super("rgb");
+
+    this._channelInputs
+      .set("r", new CssRgbChannel("r"))
+      .set("g", new CssRgbChannel("g"))
+      .set("b", new CssRgbChannel("b"))
+      .set("a", new CssAlphaChannel("a"));
+  }
+
+  convertToCssColor(value) {
+    return convertRgbToCssColor(this, value);
+  }
+}
+
+class HexColor extends Color {
+  constructor() {
+    super("hex");
+  }
+
+  convertToCssColor(value) {
+    return convertHexToCssColor(this, value);
+  }
+}
+
+class ColorChannel {
+  constructor(name) {
+    this._name = name;
+    this.nodes = [];
+  }
+
+  get name() {
+    return this._name;
+  }
+
+  get min() {
+    return 0;
+  }
+
+  get max() {
+    return 100;
+  }
+
+  get step() {
+    return 1;
+  }
+
+  convertToCssValue(value) {
+    return value;
+  }
+
+  convertToNumber(value) {
+    return value;
+  }
+}
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Syntax_3
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/angle
+ */
+class CssHueAngle extends ColorChannel {
+  get max() {
+    return 360;
+  }
+
+  convertToCssValue(value) {
+    return roundToPrecision(value);
+  }
+
+  convertToNumber(value) {
+    return convertHueAngleToNumber(value);
+  }
+}
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Syntax_3
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/percentage
+ */
+class CssPercentage extends ColorChannel {
+  convertToCssValue(value) {
+    return convertNumberToPercent(value);
+  }
+
+  convertToNumber(value) {
+    return convertPercentToNumber(value);
+  }
+}
+
+/**
+ * A number in the interval [0, 1].
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Syntax_3
+ */
+class CssAlphaChannel extends ColorChannel {
+  get max() {
+    return 1;
+  }
+
+  get step() {
+    return 0.01;
+  }
+
+  convertToCssValue(value) {
+    return roundToPrecision(value);
+  }
+
+  convertToNumber(value) {
+    return convertAlphaToNumber(value);
+  }
+}
+
+/**
+ * A number in the interval [0, 255].
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Syntax_2
+ */
+class CssRgbChannel extends ColorChannel {
+  get max() {
+    return 255;
+  }
+
+  convertToCssValue(value) {
+    return convertNumberTo8Bit(value);
+  }
+
+  convertToNumber(value) {
+    return convert8BitToNumber(value);
+  }
+}
+
+/**
+ * @param {number} value
+ * @returns {number}
+ */
+function roundToPrecision(value, decimalPrecision = 3) {
+  const p = Math.pow(10, decimalPrecision - 1);
+  return Math.round(value * p) / p;
+}
+
+/**
+ * @param {string} value
+ * @returns {number}
+ */
+
+function convertAlphaToNumber(value) {
+  if (value.endsWith("%")) {
+    return convertPercentToNumber(value);
+  }
+
+  if (value.endsWith(".")) {
+    return NaN;
+  }
+
+  return parseFloat(value);
+}
+
+/**
+ * @param {number} value
+ * @returns {string}
+ */
+function convertNumberToPercent(value) {
+  return `${roundToPrecision(value * 100)}%`;
+}
+
+/**
+ * @param {string} value
+ * @returns {number}
+ */
+function convertHueAngleToNumber(value) {
+  if (value.endsWith(".")) {
+    return NaN;
+  }
+
+  return parseFloat(value);
+}
+
+/**
+ * @param {string} value
+ * @returns {number}
+ */
+function convertPercentToNumber(value) {
+  value = value.replace(/%$/, "");
+  return parseFloat(value) / 100;
+}
+
+/**
+ * @param {string} value
+ * @returns {number}
+ */
+function convert8BitToNumber(value) {
+  return parseFloat(value) / 255;
+}
+
+/**
+ * @param {number} value
+ * @returns {number}
+ */
+function convertNumberTo8Bit(value) {
+  return roundToPrecision(value * 255);
+}
+
+function convertHslToCssColor(colorInput, color, includeAlpha = true) {
+  const colorFunction = colorInput.format + (includeAlpha ? "a" : "");
+
+  const functionArgument = Object.entries(color)
+    .filter(([channelName, _]) => includeAlpha || channelName !== "a")
+    .map(([channelName, value]) => {
+      return colorInput.channelInputs.get(channelName).convertToCssValue(value);
+    })
+    .join(", ");
+
+  const cssColor = `${colorFunction}(${functionArgument})`;
+  return cssColor;
+}
+
+function convertHsvToCssColor(colorInput, color, includeAlpha = true) {
+  return convertHslToCssColor(colorInput, color, includeAlpha);
+}
+
+function convertHwbToCssColor(colorInput, color, includeAlpha = true) {
+  return convertHslToCssColor(colorInput, color, includeAlpha);
+}
+
+function convertRgbToCssColor(colorInput, color, includeAlpha = true) {
+  return convertHslToCssColor(colorInput, color, includeAlpha);
+}
+
+function convertHexToCssColor(colorInput, color, includeAlpha = true) {
+  return includeAlpha ? color : color.slice(0, -2);
+}
+
+export { HslColor, HsvColor, HwbColor, RgbColor, HexColor };

--- a/public/js/lib/copyToClipboard.js
+++ b/public/js/lib/copyToClipboard.js
@@ -1,0 +1,33 @@
+/**
+ * https://stackoverflow.com/a/33928558/2036825
+ *
+ * @param {string} text
+ */
+function copyToClipboard(text) {
+  if (
+    !(document.queryCommandSupported && document.queryCommandSupported("copy"))
+  ) {
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.textContent = text;
+
+  // Prevent scrolling to bottom of page in MS Edge.
+  textarea.style.position = "fixed";
+
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    // Security exception may be thrown by some browsers.
+    return document.execCommand("copy");
+  } catch (error) {
+    console.warn("Copying to the clipboard failed.", error);
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export default copyToClipboard;


### PR DESCRIPTION
I’ve been working on a more accessible color picker implementation over the last two months und this is what I got. Feel free to not merge this. This is more of a nice-to-have and might be completely overkill. Also feel free to improve upon this. The implementation in Vue is a port of a pure JavaScript implementation and uses custom reactivity instead of relying on Vue. This is just the way it was implemented. We could make use of more Vue as well. ¯\_(ツ)_/¯

First things first: It turns out that depending on what they do, color pickers can be quite the big beasts. Previously, I added [vue-color](https://github.com/xiaokaike/vue-color) ([on bundlephobia](https://bundlephobia.com/result?p=vue-color@2.7.0)) to the dashboard settings in order to kick off work for #9. With this pull request, there is now a custom color picker implementation plus it is used in three places: dashboard settings, line chart cards, and number cards.

## Bundle size

Before:

```sh
👻 ll public/js/dist
-rw-r--r-- 1 phil phil  77K Jul 14 15:05 main.bundle.js
-rw-r--r-- 1 phil phil 737K Jul 14 15:05 vendors~main.bundle.js
```

After:

```sh
👻 ll public/js/dist
-rw-r--r-- 1 phil phil 101K Jul 14 15:56 main.bundle.js
-rw-r--r-- 1 phil phil 660K Jul 14 15:56 vendors~main.bundle.js
```

Looking at this, the main bundle size has increased dramatically due to pulling in the color picker in two additional places. This is somewhat expected since the current version only uses the vue-color picker in one place.

However, the vendors bundle size has decreased by an even larger amount.

## Picture

![Screenshot from 2019-07-14 16-08-04](https://user-images.githubusercontent.com/5774638/61184748-9d1d0f80-a651-11e9-8cd4-6d99d8e0db18.png)

## Moving picture

![peek9EBX4Z](https://user-images.githubusercontent.com/5774638/61184785-ed946d00-a651-11e9-9f5e-b0b277c86ff3.gif)