### PR TITLE
fix bug on editingCard variable setting when editing a card (loses changes)

### DIFF
--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -16,7 +16,7 @@
         <button
           class="inline-button edit-button"
           ref="editButton"
-          @click="editingCard = true"
+          @click="() => editingCard = true"
         >
           edit
         </button>


### PR DESCRIPTION
I noticed that there was a slight regression with handling dragging event filtering for when a card is in the editing state. If you click anywhere on the card after changing an input when in the card settings, it will reset the changes you made. This could not be reproduced when using keyboard tabbing to navigate and also save the card. So I thought it might have something with do with the app knowing if the card is being edited or not when a mousedown event is fired.

Here is a GIF showing the behaviour:

![captured](https://user-images.githubusercontent.com/1411284/61509681-8144a100-a9a4-11e9-99da-6fd23c16be2a.gif)

I did a quick manual test and it seems to have fixed the problem. It might be worth adding a test for this - thoughts? I'm about to be offline for a week so feel free to merge this if it looks good, and we can add a test later I promise 🙇 
