### PR TITLE
PR for Issue 141

### DIFF
--- a/public/css/color-picker.css
+++ b/public/css/color-picker.css
@@ -292,7 +292,6 @@
 .cp-color-preview::before {
   content: "";
   position: absolute;
-  z-index: 10;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
Here's a really small pr to remove the z-index from the .cp-color-preview class that is causing the z-index issue. There may have been a specific reason for this z-index so @kleinfreund may want to take a look but none the less, I wanted to have this ready just in case we needed to remove the style 😊 

Link to issue: https://github.com/noopkat/electric-io/issues/141