### PR TITLE
Clean up tests a bit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1872,6 +1872,21 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "24.0.15",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.15.tgz",
+      "integrity": "sha512-MU1HIvWUme74stAoc3mgAi+aMlgKOudgEvQDIm1v4RkrDudBh1T+NFp5sftpBAdXdx1J0PbdpJ+M2EsSOi1djA==",
+      "dev": true,
+      "requires": {
+        "@types/jest-diff": "*"
+      }
+    },
+    "@types/jest-diff": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
+      "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.6.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
@@ -2518,7 +2533,8 @@
     "axe-core": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.3.0.tgz",
-      "integrity": "sha512-54XaTd2VB7A6iBnXMUG2LnBOI7aRbnrVxC5Tz+rVUwYl9MX/cIJc/Ll32YUoFIE/e9UKWMZoQenQu9dFrQyZCg=="
+      "integrity": "sha512-54XaTd2VB7A6iBnXMUG2LnBOI7aRbnrVxC5Tz+rVUwYl9MX/cIJc/Ll32YUoFIE/e9UKWMZoQenQu9dFrQyZCg==",
+      "dev": true
     },
     "axios": {
       "version": "0.19.0",
@@ -13234,7 +13250,8 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@azure/event-hubs": "^2.1.1",
     "@babel/runtime": "^7.5.5",
     "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
-    "axe-core": "^3.3.0",
     "azure-iothub": "^1.10.0",
     "body-parser": "^1.19.0",
     "chart.js": "^2.8.0",
@@ -28,8 +27,7 @@
     "marked": "^0.7.0",
     "socket.io": "^2.2.0",
     "vue": "^2.6.10",
-    "vue-a11y-dialog": "^0.5.0",
-    "whatwg-fetch": "^3.0.0"
+    "vue-a11y-dialog": "^0.5.0"
   },
   "engines": {
     "node": ">= 10"
@@ -49,7 +47,9 @@
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-stage-2": "^7.0.0",
+    "@types/jest": "^24.0.15",
     "@vue/test-utils": "^1.0.0-beta.29",
+    "axe-core": "^3.3.0",
     "babel-jest": "^24.8.0",
     "babel-loader": "^8.0.6",
     "babel-minify-webpack-plugin": "^0.3.1",

--- a/public/js/components/specs/CardForm.spec.js
+++ b/public/js/components/specs/CardForm.spec.js
@@ -1,40 +1,9 @@
-import { shallowMount } from "@vue/test-utils";
-import CardForm from "../CardForm";
 import axe from "axe-core";
+import { shallowMount } from "@vue/test-utils";
 
-describe("CardFrom", () => {
-  test("component can mount", () => {
-    const wrapper = shallowMountCardForm();
+import CardForm from "../CardForm";
 
-    expect(wrapper.isVueInstance()).toBeTruthy();
-  });
-
-  test("the new FormData", () => {
-    const wrapper = shallowMountCardForm();
-    const formData = document.querySelector(".cardForm form");
-    wrapper.setProps({ editing: true });
-
-    const event = {
-      target: formData
-    };
-
-    wrapper.vm.onSubmit(event);
-
-    expect(wrapper.emitted("save-settings")).toBeTruthy();
-  });
-});
-
-test("verify component is accessible", () => {
-  const wrapper = shallowMountCardForm();
-
-  axe.run(wrapper, (err, { violations }) => {
-    expect(err).toBe(null);
-    expect(violations).toHaveLength(0);
-    done();
-  });
-});
-
-function shallowMountCardForm(props) {
+function shallowMountComponent(props = {}) {
   return shallowMount(CardForm, {
     propsData: {
       tile: {
@@ -52,3 +21,40 @@ function shallowMountCardForm(props) {
     attachToDocument: true
   });
 }
+
+describe("CardFrom", () => {
+  test("Component can be mounted", () => {
+    const wrapper = shallowMountComponent();
+
+    expect(wrapper.isVueInstance()).toBeTruthy();
+  });
+
+  test("save-settings event is emitted", () => {
+    const wrapper = shallowMountComponent();
+    const formData = document.querySelector(".cardForm form");
+    wrapper.setProps({ editing: true });
+
+    const event = {
+      target: formData
+    };
+
+    wrapper.vm.onSubmit(event);
+
+    expect(wrapper.emitted("save-settings")).toBeTruthy();
+  });
+
+  /**
+   * TODO:
+   *
+   * The Axe tests run and pass, but they don’t actually test the component in a properly mounted
+   * state. Introducing a deliberate error (i.e. an unlabeled form control) don’t make them fail.
+   *
+   * Feel free to fix them. 👋
+   */
+  test.skip("Axe doesn’t find any violations", async () => {
+    const wrapper = shallowMountComponent();
+
+    const error = await axe.run(wrapper.vm.$el);
+    expect(error).toBe(null);
+  });
+});

--- a/public/js/components/specs/DataPropertyField.spec.js
+++ b/public/js/components/specs/DataPropertyField.spec.js
@@ -1,16 +1,36 @@
-import { shallowMount } from "@vue/test-utils";
 import axe from "axe-core";
+import { shallowMount } from "@vue/test-utils";
+
 import DataPropertyField from "../DataPropertyField";
+
+function shallowMountComponent(props = {}) {
+  return shallowMount(DataPropertyField, {
+    propsData: {
+      name: "property",
+      value: "",
+      tileId: "",
+      ...props
+    }
+  });
+}
 
 describe("DataPropertyField", () => {
   test("component can mount", () => {
-    const wrapper = shallowMountDataPropertyField("property", "", "");
+    const wrapper = shallowMountComponent({
+      name: "property",
+      value: "",
+      tileId: ""
+    });
 
     expect(wrapper.isVueInstance()).toBeTruthy();
   });
 
   test("has one input element with the expected name", () => {
-    const wrapper = shallowMountDataPropertyField("unusual-property", "", "");
+    const wrapper = shallowMountComponent({
+      name: "unusual-property",
+      value: "",
+      tileId: ""
+    });
 
     const inputs = wrapper.findAll("input[name=unusual-property]");
 
@@ -22,7 +42,11 @@ describe("DataPropertyField", () => {
     const validValue = "this.is.a.valid.value";
 
     test("has aria-invalid attribute unset", () => {
-      const wrapper = shallowMountDataPropertyField("property", validValue, "");
+      const wrapper = shallowMountComponent({
+        name: "property",
+        value: validValue,
+        tileId: ""
+      });
 
       const input = wrapper.find("input[name=property]");
 
@@ -30,7 +54,11 @@ describe("DataPropertyField", () => {
     });
 
     test("has aria-describedby attribute unset", () => {
-      const wrapper = shallowMountDataPropertyField("property", validValue, "");
+      const wrapper = shallowMountComponent({
+        name: "property",
+        value: validValue,
+        tileId: ""
+      });
 
       const input = wrapper.find("input[name=property]");
 
@@ -42,11 +70,11 @@ describe("DataPropertyField", () => {
     const invalidValue = "this is not a valid value";
 
     test("has aria-invalid attribute set to 'true'", () => {
-      const wrapper = shallowMountDataPropertyField(
-        "property",
-        invalidValue,
-        ""
-      );
+      const wrapper = shallowMountComponent({
+        name: "property",
+        value: invalidValue,
+        tileId: ""
+      });
 
       const input = wrapper.find("input[name=property]");
 
@@ -54,11 +82,11 @@ describe("DataPropertyField", () => {
     });
 
     test("has aria-describedby attribute set to an element that exists in the component", () => {
-      const wrapper = shallowMountDataPropertyField(
-        "property",
-        invalidValue,
-        ""
-      );
+      const wrapper = shallowMountComponent({
+        name: "property",
+        value: invalidValue,
+        tileId: ""
+      });
 
       const input = wrapper.find("input[name=property]");
       const attributeValue = input.attributes("aria-describedby");
@@ -69,23 +97,18 @@ describe("DataPropertyField", () => {
     });
   });
 
-  test("verify component is accessible", () => {
-    const wrapper = shallowMountDataPropertyField("property", "value", "");
+  /**
+   * TODO:
+   *
+   * The Axe tests run and pass, but they don’t actually test the component in a properly mounted
+   * state. Introducing a deliberate error (i.e. an unlabeled form control) don’t make them fail.
+   *
+   * Feel free to fix them. 👋
+   */
+  test.skip("Axe doesn’t find any violations", async () => {
+    const wrapper = shallowMountComponent();
 
-    axe.run(wrapper, (err, { violations }) => {
-      expect(err).toBe(null);
-      expect(violations).toHaveLength(0);
-      done();
-    });
+    const error = await axe.run(wrapper.vm.$el);
+    expect(error).toBe(null);
   });
 });
-
-function shallowMountDataPropertyField(name, value, tileId) {
-  return shallowMount(DataPropertyField, {
-    propsData: {
-      name: name,
-      value: value,
-      tileId: tileId
-    }
-  });
-}

--- a/public/js/components/specs/LineChartCard.spec.js
+++ b/public/js/components/specs/LineChartCard.spec.js
@@ -1,87 +1,10 @@
-import { shallowMount } from "@vue/test-utils";
-import LineChartCard from "../LineChartCard";
-import Chart from "chart.js";
 import axe from "axe-core";
+import { shallowMount } from "@vue/test-utils";
+import Chart from "chart.js";
 
-jest.mock("chart.js");
+import LineChartCard from "../LineChartCard";
 
-describe("LineChartCard", () => {
-  test("component can mount", () => {
-    const wrapper = shallowMountLineChartCard();
-
-    expect(wrapper.isVueInstance()).toBeTruthy();
-  });
-
-  test("new Chart is called in mounted lifecycle hook", () => {
-    const { vm } = shallowMountLineChartCard();
-    vm.chart.update = jest.fn();
-
-    expect(Chart).toHaveBeenCalled();
-  });
-
-  test("computes the CanvasStyle width and height object and object property values", () => {
-    const { vm } = shallowMountLineChartCard();
-
-    // Test the object returned in the computed method
-    expect(vm.canvasStyle).toEqual(
-      expect.objectContaining({
-        width: expect.any(String),
-        height: expect.any(String)
-      })
-    );
-
-    // Test the calcuation based upon the mock propsData
-    expect(vm.canvasStyle).toEqual({
-      height: "305px",
-      width: "370px"
-    });
-  });
-
-  test("the update of messages data based upon the watcher", () => {
-    const spy = jest.spyOn(LineChartCard.watch, "messages");
-    const wrapper = shallowMountLineChartCard({
-      messages: [],
-      blockSize: [200, 250],
-      tile: {
-        deviceId: "AZ3166",
-        id: "ac57912f-1a04-4cc2-a587-1bc116e8cc54",
-        lineColor: "#FF6384",
-        position: [200, 246],
-        property: "",
-        size: [2, 1.5],
-        title: "Line Chart",
-        type: "line-chart"
-      }
-    });
-
-    expect(spy).toHaveBeenCalledTimes(0);
-
-    wrapper.setProps({
-      messages: [
-        {
-          deviceId: "BU2802",
-          enqueuedTime: "2019-06-03T11:45:10.125Z",
-          humidity: 32.800208338,
-          temperature: 45.13494407
-        }
-      ]
-    });
-
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  test("verify component is accessible", () => {
-    const { vm } = shallowMountLineChartCard();
-
-    axe.run(vm, (err, { violations }) => {
-      expect(err).toBe(null);
-      expect(violations).toHaveLength(0);
-      done();
-    });
-  });
-});
-
-function shallowMountLineChartCard(props) {
+function shallowMountComponent(props = {}) {
   return shallowMount(LineChartCard, {
     propsData: {
       tile: {
@@ -113,3 +36,86 @@ function shallowMountLineChartCard(props) {
     }
   });
 }
+
+jest.mock("chart.js");
+
+describe("LineChartCard", () => {
+  test("component can mount", () => {
+    const wrapper = shallowMountComponent();
+
+    expect(wrapper.isVueInstance()).toBeTruthy();
+  });
+
+  test("new Chart is called in mounted lifecycle hook", () => {
+    const { vm } = shallowMountComponent();
+    vm.chart.update = jest.fn();
+
+    expect(Chart).toHaveBeenCalled();
+  });
+
+  test("computes the CanvasStyle width and height object and object property values", () => {
+    const { vm } = shallowMountComponent();
+
+    // Test the object returned in the computed method
+    expect(vm.canvasStyle).toEqual(
+      expect.objectContaining({
+        width: expect.any(String),
+        height: expect.any(String)
+      })
+    );
+
+    // Test the calcuation based upon the mock propsData
+    expect(vm.canvasStyle).toEqual({
+      height: "305px",
+      width: "370px"
+    });
+  });
+
+  test("the update of messages data based upon the watcher", () => {
+    const spy = jest.spyOn(LineChartCard.watch, "messages");
+    const wrapper = shallowMountComponent({
+      messages: [],
+      blockSize: [200, 250],
+      tile: {
+        deviceId: "AZ3166",
+        id: "ac57912f-1a04-4cc2-a587-1bc116e8cc54",
+        lineColor: "#FF6384",
+        position: [200, 246],
+        property: "",
+        size: [2, 1.5],
+        title: "Line Chart",
+        type: "line-chart"
+      }
+    });
+
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    wrapper.setProps({
+      messages: [
+        {
+          deviceId: "BU2802",
+          enqueuedTime: "2019-06-03T11:45:10.125Z",
+          humidity: 32.800208338,
+          temperature: 45.13494407
+        }
+      ]
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * TODO:
+   *
+   * The Axe tests run and pass, but they don’t actually test the component in a properly mounted
+   * state. Introducing a deliberate error (i.e. an unlabeled form control) don’t make them fail.
+   *
+   * Feel free to fix them. 👋
+   */
+  test.skip("Axe doesn’t find any violations", async () => {
+    const wrapper = shallowMountComponent();
+
+    const error = await axe.run(wrapper.vm.$el);
+    expect(error).toBe(null);
+  });
+});

--- a/public/js/components/specs/LineChartSettings.spec.js
+++ b/public/js/components/specs/LineChartSettings.spec.js
@@ -1,59 +1,9 @@
-import { shallowMount } from "@vue/test-utils";
-import LineChartSettings from "../LineChartSettings";
 import axe from "axe-core";
+import { shallowMount } from "@vue/test-utils";
 
-describe("LineChartSettings", () => {
-  test("component can mount", () => {
-    const wrapper = shallowMountLineChartSettings();
+import LineChartSettings from "../LineChartSettings";
 
-    expect(wrapper.isVueInstance()).toBeTruthy();
-  });
-
-  test("the deviceList prop is populated", () => {
-    const { vm } = shallowMountLineChartSettings();
-
-    expect(vm.deviceList.length).toBe(3);
-  });
-
-  test("that there is a device ID field in the LineChartSettings window", () => {
-    const wrapper = shallowMountLineChartSettings();
-
-    const elements = wrapper.findAll("[name=deviceId]");
-
-    expect(elements.exists()).toBe(true);
-    expect(elements.length).toEqual(1);
-  });
-
-  test("that there is a data property field in the LineChartSettings window", () => {
-    const wrapper = shallowMountLineChartSettings();
-
-    const elements = wrapper.findAll("[name=property]");
-
-    expect(elements.exists()).toBe(true);
-    expect(elements.length).toEqual(1);
-  });
-
-  test("that there is a line color field in the LineChartSettings window", () => {
-    const wrapper = shallowMountLineChartSettings();
-
-    const elements = wrapper.findAll("[name=lineColor]");
-
-    expect(elements.exists()).toBe(true);
-    expect(elements.length).toEqual(1);
-  });
-
-  test("verify component is accessible", () => {
-    const wrapper = shallowMountLineChartSettings();
-
-    axe.run(wrapper, (err, { violations }) => {
-      expect(err).toBe(null);
-      expect(violations).toHaveLength(0);
-      done();
-    });
-  });
-});
-
-function shallowMountLineChartSettings() {
+function shallowMountComponent(props = {}) {
   return shallowMount(LineChartSettings, {
     propsData: {
       tile: {
@@ -67,6 +17,70 @@ function shallowMountLineChartSettings() {
         type: "line-chart"
       },
       deviceList: ["AZ3166", "Tessel2", "Jenn"]
-    }
+    },
+    ...props
   });
 }
+
+describe("LineChartSettings", () => {
+  test("component can mount", () => {
+    const wrapper = shallowMountComponent();
+
+    expect(wrapper.isVueInstance()).toBeTruthy();
+  });
+
+  test("the deviceList prop is populated", () => {
+    const { vm } = shallowMountComponent();
+
+    expect(vm.deviceList.length).toBe(3);
+  });
+
+  test("that there is a device ID field in the LineChartSettings window", () => {
+    const wrapper = shallowMountComponent();
+
+    const elements = wrapper.findAll("[name=deviceId]");
+
+    expect(elements.exists()).toBe(true);
+    expect(elements.length).toEqual(1);
+  });
+
+  test("that there is a data property field in the LineChartSettings window", () => {
+    const wrapper = shallowMountComponent();
+
+    const elements = wrapper.findAll("[name=property]");
+
+    expect(elements.exists()).toBe(true);
+    expect(elements.length).toEqual(1);
+  });
+
+  test("that there is a line color field in the LineChartSettings window", () => {
+    const wrapper = shallowMountComponent();
+
+    const elements = wrapper.findAll("[name=lineColor]");
+
+    expect(elements.exists()).toBe(true);
+    expect(elements.length).toEqual(1);
+  });
+
+  test("updateValue()", () => {
+    const wrapper = shallowMountComponent();
+    const spy = jest.spyOn(wrapper.vm, "updateValue");
+    wrapper.vm.updateValue("#ff8800");
+    expect(spy).toBeCalled();
+  });
+
+  /**
+   * TODO:
+   *
+   * The Axe tests run and pass, but they don’t actually test the component in a properly mounted
+   * state. Introducing a deliberate error (i.e. an unlabeled form control) don’t make them fail.
+   *
+   * Feel free to fix them. 👋
+   */
+  test.skip("Axe doesn’t find any violations", async () => {
+    const wrapper = shallowMountComponent();
+
+    const error = await axe.run(wrapper.vm.$el);
+    expect(error).toBe(null);
+  });
+});

--- a/public/js/components/specs/NumberCard.spec.js
+++ b/public/js/components/specs/NumberCard.spec.js
@@ -1,23 +1,39 @@
-import { shallowMount } from "@vue/test-utils";
-import NumberCard from "../NumberCard";
 import axe from "axe-core";
+import { shallowMount } from "@vue/test-utils";
+
+import NumberCard from "../NumberCard";
+
+function shallowMountComponent(props = {}) {
+  return shallowMount(NumberCard, {
+    propsData: {
+      tile: {
+        textColor: "blue"
+      },
+      ...props
+    },
+
+    data: () => ({
+      number: 1
+    })
+  });
+}
 
 describe("NumberCard", () => {
   test("component can mount", () => {
-    const wrapper = shallowMountNumberCard();
+    const wrapper = shallowMountComponent();
 
     expect(wrapper.isVueInstance()).toBeTruthy();
   });
 
   test("renders with color and number value", () => {
-    const wrapper = shallowMountNumberCard();
+    const wrapper = shallowMountComponent();
 
     expect(wrapper.html()).toMatchSnapshot();
   });
 
   test("the messages watch method", () => {
     const spy = jest.spyOn(NumberCard.watch, "messages");
-    const wrapper = shallowMountNumberCard({
+    const wrapper = shallowMountComponent({
       messages: []
     });
 
@@ -43,28 +59,18 @@ describe("NumberCard", () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  test("verify component is accessible", () => {
-    const wrapper = shallowMountNumberCard();
+  /**
+   * TODO:
+   *
+   * The Axe tests run and pass, but they don’t actually test the component in a properly mounted
+   * state. Introducing a deliberate error (i.e. an unlabeled form control) don’t make them fail.
+   *
+   * Feel free to fix them. 👋
+   */
+  test.skip("Axe doesn’t find any violations", async () => {
+    const wrapper = shallowMountComponent();
 
-    axe.run(wrapper, (err, { violations }) => {
-      expect(err).toBe(null);
-      expect(violations).toHaveLength(0);
-      done();
-    });
+    const error = await axe.run(wrapper.vm.$el);
+    expect(error).toBe(null);
   });
 });
-
-function shallowMountNumberCard(props = {}) {
-  return shallowMount(NumberCard, {
-    propsData: {
-      tile: {
-        textColor: "blue"
-      },
-      ...props
-    },
-
-    data: () => ({
-      number: 1
-    })
-  });
-}

--- a/public/js/lib/colorContraster.js
+++ b/public/js/lib/colorContraster.js
@@ -71,7 +71,12 @@ function parseRGB(color) {
 function parseName(color) {
   // papayawhip or Papaya Whip
   const justColor = color.replace(/\s/g, "").toLowerCase();
-  const hexColor = colorNames[color];
+  const hexColor = colorNames[justColor];
+
+  if (hexColor === undefined) {
+    return null;
+  }
+
   return parseHex(hexColor);
 }
 


### PR DESCRIPTION
- Removed `whatwg-fetch` from dependencies (only needed as devDependency)
- <del>Removed all Axe tests.</del><ins>Skipped all Axe tests.</ins> We never actually tested anything with them. The Axe tests just passed because we were testing some kind of empty component/page fragment. Introducing a deliberate error like an unlabeled input element or an empty heading didn’t break the tests. I currently see no way of getting these tests to work properly. :(
- Added `@types/jest` as a devDependency. This removes the errors on test-related functions like `describe` and `test` that are shown in some editors/IDEs (e.g. VS Code)
- Streamlined the `shallowMountComponent` helper function across the tests so it is used the same way in all tests. This should make it easier for future contributors to understand what’s going on there.