### PR TITLE
restore binding to cardform tile id field

### DIFF
--- a/public/js/components/CardForm.vue
+++ b/public/js/components/CardForm.vue
@@ -3,7 +3,7 @@
     <h2>Settings</h2>
 
     <form @submit.prevent="onSubmit">
-      <input name="id" type="hidden" value="tile.id" />
+      <input name="id" type="hidden" :value="tile.id" />
 
       <label>
         Title


### PR DESCRIPTION
A tiny regression that snuck in with some maintenance work 🔍 

I noticed it when I was working on #144. The cards weren't saving changes correctly and I traced it back to the id not binding correctly in the hidden tile id form field in the card settings component.

Let me know if this is a real bug this time! 😅 
