### PR TITLE
Update markdown readme header for inter-page links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We have two different ways you can do this. You can do this via the [native inst
 
 7. Navigate to `http://localhost:3000` in your favourite modern browser and away you go! Try adding new cards via the settings pane on the right and click “edit” to fill in the details.
 
-### Docker Installation Method
+### Docker Installation
 
 #### Install Docker
 


### PR DESCRIPTION
I stumbled on this bug that our anchor link didn't match the markdown heading for the docker section. This will fix that.

I know it's tiny, but... it's worth it :)

![bitmoji](https://render.bitstrips.com/v2/cpanel/fe4a1c10-cce9-4b4a-a43c-6e707afcc5d1-c3b45c6e-2943-4fd5-ab6e-fe23bffcb90b-v1.png?transparent=1&palette=1&width=246)