### PR TITLE
Updated vue library from 2.6.10 to 2.6.11 to match vue-template-compiler version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16007,9 +16007,9 @@
       "dev": true
     },
     "vue": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
+      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
     },
     "vue-a11y-dialog": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jmespath": "^0.15.0",
     "marked": "^0.8.0",
     "socket.io": "^2.3.0",
-    "vue": "^2.6.10",
+    "vue": "^2.6.11",
     "vue-a11y-dialog": "^0.5.0"
   },
   "engines": {


### PR DESCRIPTION
Updated vue library from 2.6.10 to 2.6.11 to match vue-template-compiler version

#193 (Crashing due to vue-template-compiler and vue having different versions)