### PR TITLE
Update event-hubs to 5.0.1

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,7 @@
 
 # note: .env is a shell file so there can't be spaces around '=
 
-CONNECTION_STRING=''
+IOTHUB_CONNECTION_STRING=''
+EVENTHUB_CONNECTION_STRING=''
 CONSUMER_GROUP=''
 SIMULATING=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,13 @@ Hey! Thanks for your interest in contributing to this project! I really apprecia
 This page should get you up and running with how to run locally and how to adhere to this project’s style guide also.
 
 1. [Installation](#installation)
-    - [With a real Azure IoT Hub](#with-a-real-azure-iot-hub)
-    - [With the device and hub simulator](#with-the-built-in-device-and-hub-simulator)
+   - [With a real Azure IoT Hub](#with-a-real-azure-iot-hub)
+   - [With the device and hub simulator](#with-the-built-in-device-and-hub-simulator)
 2. [Style guide](#style-guide)
-    - [Tests](#tests)
-    - [Mobile support](#mobile-support)
+   - [Tests](#tests)
+   - [Mobile support](#mobile-support)
 3. [Pull requests](#pull-requests)
-    - [Avoiding merge conflicts](#merge-conflicts)
+   - [Avoiding merge conflicts](#merge-conflicts)
 
 ## Installation
 
@@ -21,9 +21,13 @@ When developing electric-io locally, you have two options for ensuring you can t
 
 You’ll need to have an Azure IoT Hub instance of your own running in Azure, as this is what the dashboard is designed for. If you’d like to see more IoT messaging providers, let me know by [opening an issue](https://github.com/noopkat/electric-io/issues/new?title=Request+to+add+messaging+provider).
 
-You’ll need to have your Azure IoT Hub connection string handy. You can find it under your “Shared Access Policies” section in the IoT Hub’s Azure Portal blade. Choose a policy that allows “registry read”, “service connect” and “device connect” at the least.
+You’ll need to have your Azure IoT Hub connection string and Event Hub-compatible endpoint connection string handy.
 
-You can also list your connections strings [via the command line](https://docs.microsoft.com/en-us/cli/azure/iot/hub?view=azure-cli-latest#az-iot-hub-show-connection-string)!
+- You can find your Iot Hub connection string under the “Shared Access Policies” section in the IoT Hub’s Azure Portal blade. Choose a policy that allows “registry read”, “service connect” and “device connect” at the least.
+
+  You can also list your connections strings [via the command line](https://docs.microsoft.com/en-us/cli/azure/iot/hub?view=azure-cli-latest#az-iot-hub-show-connection-string).
+
+- You can find your Event Hub-compatible endpoint connection string under the “Built-in endpoints” section in the IoT Hub's Azure Portal blade.
 
 **Now you’re ready to install the app.**
 
@@ -31,35 +35,35 @@ You can also list your connections strings [via the command line](https://docs.m
 2. Install [Git](https://git-scm.org).
 3. Open your terminal and do the following:
 
-    1. Clone the [electric-io repository](https://github.com/noopkat/electric-io):
+   1. Clone the [electric-io repository](https://github.com/noopkat/electric-io):
 
-        ```
-        git clone https://github.com/noopkat/electric-io.git
-        ```
+      ```
+      git clone https://github.com/noopkat/electric-io.git
+      ```
 
-        If this fails with an error message, you can [have a look at GitHub HTTPS cloning errors](https://help.github.com/articles/https-cloning-errors/).
+      If this fails with an error message, you can [have a look at GitHub HTTPS cloning errors](https://help.github.com/articles/https-cloning-errors/).
 
-    2. Navigate to the electric-iodirectory:
+   2. Navigate to the electric-iodirectory:
 
-        ```
-        cd electric-io
-        ```
+      ```
+      cd electric-io
+      ```
 
-    3. Install electric-io’s dependencies:
+   3. Install electric-io’s dependencies:
 
-        ```
-        npm install
-        ```
+      ```
+      npm install
+      ```
 
-        If this fails with an error message, you can [have a look at common NPM errors](https://docs.npmjs.com/common-errors).
+      If this fails with an error message, you can [have a look at common NPM errors](https://docs.npmjs.com/common-errors).
 
-4. Open the file `.env` in and fill in the `CONNECTION_STRING` property with your Azure IoT Hub connection string.
+4. Open the file `.env` in a text editor. Fill in the `IOTHUB_CONNECTION_STRING` property with your Azure IoT Hub connection string. Fill in the `EVENTHUB_CONNECTION_STRING` property with your Event Hub-compatible endpoint connection string.
 5. Optional. Specify the `CONSUMER_GROUP` in `.env`. _If in doubt, you can skip this step_.
 6. Go back to your terminal and start electric-io:
 
-    ```
-    npm start
-    ```
+   ```
+   npm start
+   ```
 
 7. Navigate to `http://localhost:3000` in your favourite modern browser and away you go! Try adding new cards via the settings pane on the right and click “edit” to fill in the details.
 
@@ -71,11 +75,11 @@ This application also features a simulator that features three “devices” tha
 2. Navigate to the `.data` directory where you’ll note a file called `dashboard.json.sim`. Copy this file to the same directory and name it `dashboard.json`. This will set you up with a pre-made dashboard layout with some cards already listening to data from the simulated devices 😎
 3. In your terminal, run:
 
-    ```
-    SIMULATING=true npm start
-    ```
+   ```
+   SIMULATING=true npm start
+   ```
 
-    On Windows, run `set SIMULATING=true`, then run `npm start`.
+   On Windows, run `set SIMULATING=true`, then run `npm start`.
 
 4. Navigate to `http://localhost:3000` in your favourite modern browser and away you go!
 
@@ -88,8 +92,8 @@ Example payload:
 
 ```json
 {
-    "temperature": 25.8976,
-    "humidity": 40.679
+  "temperature": 25.8976,
+  "humidity": 40.679
 }
 ```
 
@@ -102,8 +106,8 @@ Example payload:
 
 ```json
 {
-    "light": 0.45689,
-    "sound": 0.23878
+  "light": 0.45689,
+  "sound": 0.23878
 }
 ```
 
@@ -116,7 +120,7 @@ Example payload:
 
 ```json
 {
-    "coolness": 98.56
+  "coolness": 98.56
 }
 ```
 
@@ -126,9 +130,9 @@ ESLint is installed by default with this repository, and many IDEs will automati
 
 This said, some caveats remain in order to keep this approachable:
 
--   Target NodeJS 10+
--   Stick to plain CSS. SASS/SCSS is probably a little much for this project anyway.
--   Idiomatic Vue style. This is way less scary than it might sound. Please keep things looking like the documentation. 🌻
+- Target NodeJS 10+
+- Stick to plain CSS. SASS/SCSS is probably a little much for this project anyway.
+- Idiomatic Vue style. This is way less scary than it might sound. Please keep things looking like the documentation. 🌻
 
 If you want a build toolchain for doing extra things like SASS or Vue related transpiling, go for it! But please do this in your own fork and keep it as your own project rather than trying to change this one 💜
 
@@ -183,10 +187,10 @@ git merge master
 
 This will:
 
--   Switch to your own `master` branch
--   Download changes from the primary repository `noopkat/electric-io`
--   Switch back to your `feature/...` or `issue/...` branch
--   Merge changes into your branch
+- Switch to your own `master` branch
+- Download changes from the primary repository `noopkat/electric-io`
+- Switch back to your `feature/...` or `issue/...` branch
+- Merge changes into your branch
 
 You can then `git push` to update the PR if you’ve already submitted one.
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ This will be remixable on Glitch pretty soon, but if you want to run it locally 
 
 You’ll need to have an Azure IoT Hub instance of your own running in Azure, as this is what the dashboard is designed for. If you’d like to see more IoT messaging providers, let me know by [opening an issue](https://github.com/noopkat/electric-io/issues/new?title=Request+to+add+messaging+provider).
 
-You’ll need to have your Azure IoT Hub connection string handy. You can find it under your “Shared Access Policies” section in the IoT Hub’s Azure Portal blade. Choose a policy that allows “registry read”, “service connect” and “device connect” at the least.
+You’ll need to have your Azure IoT Hub connection string and Event Hub-compatible endpoint connection string handy.
 
-You can also list your connections strings [via the command line](https://docs.microsoft.com/en-us/cli/azure/iot/hub?view=azure-cli-latest#az-iot-hub-show-connection-string).
+- You can find your Iot Hub connection string under the “Shared Access Policies” section in the IoT Hub’s Azure Portal blade. Choose a policy that allows “registry read”, “service connect” and “device connect” at the least.
+
+  You can also list your connections strings [via the command line](https://docs.microsoft.com/en-us/cli/azure/iot/hub?view=azure-cli-latest#az-iot-hub-show-connection-string).
+
+- You can find your Event Hub-compatible endpoint connection string under the “Built-in endpoints” section in the IoT Hub's Azure Portal blade.
 
 **Now you’re ready to install the app.**
 
@@ -64,7 +68,7 @@ We have two different ways you can do this. You can do this via the [native inst
 
       If this fails with an error message, you can [have a look at common NPM errors](https://docs.npmjs.com/common-errors).
 
-4. Open the file `.env` in and fill in the `CONNECTION_STRING` property with your Azure IoT Hub connection string.
+4. Open the file `.env` in a text editor. Fill in the `IOTHUB_CONNECTION_STRING` property with your Azure IoT Hub connection string. Fill in the `EVENTHUB_CONNECTION_STRING` property with your Event Hub-compatible endpoint connection string.
 5. Optional. Specify the `CONSUMER_GROUP` in `.env`. _If in doubt, you can skip this step_.
 6. Go back to your terminal and start electric-io:
 

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -11,9 +11,11 @@ services:
       - DEBUG
       - CONSUMER_GROUP
       - PLATFORM=azure
-      - CONNECTION_STRING=<IoTHubConnectionString>
+      - IOTHUB_CONNECTION_STRING=<IoTHubConnectionString>
+      - EVENTTHUB_CONNECTION_STRING=<EventHubConnectionString>
       - EDIT_MODE=unlocked
     volumes: # For file editing, watching, etc
       - electric-io:/usr/app
       - /usr/app/node_modules
-volumes: electric-io:
+volumes:
+  electric-io:

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -12,7 +12,7 @@ services:
       - CONSUMER_GROUP
       - PLATFORM=azure
       - IOTHUB_CONNECTION_STRING=<IoTHubConnectionString>
-      - EVENTTHUB_CONNECTION_STRING=<EventHubConnectionString>
+      - EVENTHUB_CONNECTION_STRING=<EventHubConnectionString>
       - EDIT_MODE=unlocked
     volumes: # For file editing, watching, etc
       - electric-io:/usr/app

--- a/lib/liveHub.js
+++ b/lib/liveHub.js
@@ -1,17 +1,24 @@
-const { EventHubClient, EventPosition } = require("@azure/event-hubs");
+const {
+  EventHubConsumerClient,
+  latestEventPosition
+} = require("@azure/event-hubs");
 const iothub = require("azure-iothub");
-let ehClient;
 
 function startService(options) {
-  const { connectionString } = options;
-  if (!connectionString) {
+  const { iotHubConnectionString, eventHubConnectionString } = options;
+  if (!iotHubConnectionString) {
     throw new Error(
-      "oops, you're missing a CONNECTION_STRING entry in ./.env!"
+      "oops, you're missing an IOTHUB_CONNECTION_STRING entry in ./.env!"
+    );
+  }
+  if (!eventHubConnectionString) {
+    throw new Error(
+      "oops, you're missing an EVENTHUB_CONNECTION_STRING entry in ./.env!"
     );
   }
 
-  const registry = iothub.Registry.fromConnectionString(connectionString);
-  const client = iothub.Client.fromConnectionString(connectionString);
+  const registry = iothub.Registry.fromConnectionString(iotHubConnectionString);
+  const client = iothub.Client.fromConnectionString(iotHubConnectionString);
   return startHub(options).then(() => {
     return {
       listDevices: registry.list.bind(registry),
@@ -22,13 +29,14 @@ function startService(options) {
 }
 
 function startHub(options) {
-  return EventHubClient.createFromIotHubConnectionString(
-    options.connectionString
-  )
-    .then(client => (ehClient = client))
-    .then(() => ehClient.getPartitionIds())
+  const ehClient = new EventHubConsumerClient(
+    options.consumerGroup,
+    options.eventHubConnectionString
+  );
+  return ehClient
+    .getPartitionIds()
     .then(partitionIds => filterPartitions(options, partitionIds))
-    .then(partitionIds => generateReceivers(options, partitionIds));
+    .then(partitionIds => generateReceivers(options, partitionIds, ehClient));
 }
 
 function filterPartitions(options, partitionIds) {
@@ -40,22 +48,23 @@ function filterPartitions(options, partitionIds) {
   });
 }
 
-function generateReceivers(options, partitionIds) {
-  const { startTime, consumerGroup, receiveHandler, errorHandler } = options;
+function generateReceivers(options, partitionIds, ehClient) {
+  const { consumerGroup, receiveHandler, errorHandler } = options;
 
-  const receiveOptions = {
-    enqueuedTime: startTime,
-    eventPosition: EventPosition.fromEnqueuedTime(startTime),
+  const subscribeOptions = {
+    startPosition: latestEventPosition,
     consumerGroup: consumerGroup
   };
 
+  const eventHandlers = {
+    processEvents: events => {
+      events.forEach(e => receiveHandler(e));
+    },
+    processError: errorHandler
+  };
+
   return partitionIds.map(partitionId => {
-    return ehClient.receive(
-      partitionId,
-      receiveHandler,
-      errorHandler,
-      receiveOptions
-    );
+    return ehClient.subscribe(partitionId, eventHandlers, subscribeOptions);
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,120 +4,229 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@azure/amqp-common": {
-      "version": "1.0.0-preview.6",
-      "resolved": "https://registry.npmjs.org/@azure/amqp-common/-/amqp-common-1.0.0-preview.6.tgz",
-      "integrity": "sha512-5XJZaJGtGoPmLhFx5y0vfCXiAHksoA4fdSnHAfkgEm4krhCW1jt1LH/6aJdUwUTJe+bz6m3Pv0sG/ILG0Vd65g==",
+    "@azure/abort-controller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.1.tgz",
+      "integrity": "sha512-wP2Jw6uPp8DEDy0n4KNidvwzDjyVV2xnycEIq7nPzj1rHyb/r+t3OPeNT1INZePP2wy5ZqlwyuyOMTi0ePyY1A==",
       "requires": {
-        "@azure/ms-rest-nodeauth": "^0.9.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@azure/core-amqp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-amqp/-/core-amqp-1.1.0.tgz",
+      "integrity": "sha512-P+gfwryFqi7K1PL8gQ6c5AuGtUmOhbpzJk1LIURjmjgGxMpJAeTkMk+/KHo3SXfuQm5vRt6eNLIa8EPqvx4Krw==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.0.0",
+        "@azure/logger": "^1.0.0",
         "@types/async-lock": "^1.1.0",
         "@types/is-buffer": "^2.0.0",
         "async-lock": "^1.1.3",
         "buffer": "^5.2.1",
-        "debug": "^3.1.0",
+        "debug": "^4.1.1",
         "events": "^3.0.0",
         "is-buffer": "^2.0.3",
         "jssha": "^2.3.1",
         "process": "^0.11.10",
+        "rhea": "^1.0.18",
+        "rhea-promise": "^1.0.0",
         "stream-browserify": "^2.0.2",
-        "tslib": "^1.9.3",
+        "tslib": "^1.10.0",
         "url": "^0.11.0",
-        "util": "^0.11.1"
+        "util": "^0.12.1"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
           }
         },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "rhea": {
+          "version": "1.0.19",
+          "resolved": "https://registry.npmjs.org/rhea/-/rhea-1.0.19.tgz",
+          "integrity": "sha512-52fctFB6zZ+n2nMo1HvreC4HzV8FwSH7zZyTdMXxNaDMDWeVbZo42cjGeJh8+BZMC1+r7YUZrd3p4cNVAfJf1Q==",
+          "requires": {
+            "debug": "0.8.0 - 3.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
+          }
+        },
+        "util": {
+          "version": "0.12.2",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.2.tgz",
+          "integrity": "sha512-XE+MkWQvglYa+IOfBt5UFG93EmncEMP23UqpgDvVZVFBPxwmkK10QRp6pgU4xICPnWRf/t0zPv4noYSUq9gqUQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "safe-buffer": "^5.1.2"
+          }
         }
       }
     },
-    "@azure/event-hubs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@azure/event-hubs/-/event-hubs-2.1.1.tgz",
-      "integrity": "sha512-nGnFBPcB/rs+5YWwmHJg+d3Cs7BrjtVfuD1eEv8j+ui2X6uXxB88wom1A2t/7xsSzkunQSrXJ2mCwdHxKI5aHw==",
+    "@azure/core-asynciterator-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+    },
+    "@azure/core-auth": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.0.2.tgz",
+      "integrity": "sha512-zhPJObdrhz2ymIqGL1x8i3meEuaLz0UPjH9mOq9RGOlJB2Pb6K6xPtkHbRsfElgoO9USR4hH2XU5pLa4/JHHIw==",
       "requires": {
-        "@azure/amqp-common": "^1.0.0-preview.5",
-        "@azure/ms-rest-nodeauth": "^0.9.2",
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-tracing": "1.0.0-preview.7",
+        "@opentelemetry/types": "^0.2.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@azure/core-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.0.4.tgz",
+      "integrity": "sha512-UhQ4Tpgv6a/7fmvleXEpyQAg8FWcemqzAPY2F75QBygEDD4Hsz2fFujTAEUBQ1an+eNQjzk7EC7TTbqXOmiwAw==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.0.0",
+        "@azure/core-tracing": "1.0.0-preview.7",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/types": "^0.2.0",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.1",
+        "cross-env": "^6.0.3",
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0",
+        "process": "^0.11.10",
+        "tough-cookie": "^3.0.1",
+        "tslib": "^1.10.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^3.3.2",
+        "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.0.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.7.tgz",
+      "integrity": "sha512-pkFCw6OiJrpR+aH1VQe6DYm3fK2KWCC5Jf3m/Pv1RxF08M1Xm08RCyQ5Qe0YyW5L16yYT2nnV48krVhYZ6SGFA==",
+      "requires": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/types": "^0.2.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@azure/event-hubs": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/event-hubs/-/event-hubs-5.0.1.tgz",
+      "integrity": "sha512-f4MKGbu7MsVvp4yxsjcO42t8+2YcT/jLdVmNUbP2kLuZu0Vzh2Z/cebrw5v4PbPfmmcOPbOrZ1aJBaJV2o0v6w==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-amqp": "^1.0.1",
+        "@azure/core-asynciterator-polyfill": "^1.0.0",
+        "@azure/core-tracing": "1.0.0-preview.7",
+        "@azure/identity": "^1.0.0",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/types": "^0.2.0",
         "async-lock": "^1.1.3",
-        "debug": "^3.1.0",
+        "buffer": "^5.2.1",
+        "debug": "^4.1.1",
         "is-buffer": "^2.0.3",
         "jssha": "^2.3.1",
-        "rhea-promise": "^0.1.15",
+        "process": "^0.11.10",
+        "rhea-promise": "^1.0.0",
+        "tslib": "^1.10.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
+      }
+    },
+    "@azure/identity": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-1.0.2.tgz",
+      "integrity": "sha512-kGGiRT9pSlo7Op8I9gBtjufUaqe4AqQv+nPWVOmdDBaf3zD0rPa7zHnDT6dHP/oNdBjlxDczf7Ks+s9KdtAmag==",
+      "requires": {
+        "@azure/core-http": "^1.0.0",
+        "@azure/core-tracing": "1.0.0-preview.7",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/types": "^0.2.0",
+        "events": "^3.0.0",
+        "jws": "^3.2.2",
+        "msal": "^1.0.2",
+        "qs": "^6.7.0",
         "tslib": "^1.9.3",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        "qs": {
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
         }
       }
     },
-    "@azure/ms-rest-azure-env": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-1.1.2.tgz",
-      "integrity": "sha512-l7z0DPCi2Hp88w12JhDTtx5d0Y3+vhfE7JKJb9O7sEz71Cwp053N8piTtTnnk/tUor9oZHgEKi/p3tQQmLPjvA=="
-    },
-    "@azure/ms-rest-js": {
-      "version": "1.8.13",
-      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.13.tgz",
-      "integrity": "sha512-jAa6Y2XrvwbEqkaEXDHK+ReNo0WnCPS+LgQ1dRAJUUNxK4CghF5u+SXsVtPENritilVE7FVteqsLOtlhTk+haA==",
+    "@azure/logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.0.tgz",
+      "integrity": "sha512-g2qLDgvmhyIxR3JVS8N67CyIOeFRKQlX/llxYJQr1OSGQqM3HTpVP8MjmjcEKbL/OIt2N9C9UFaNQuKOw1laOA==",
       "requires": {
-        "@types/tunnel": "0.0.0",
-        "axios": "^0.19.0",
-        "form-data": "^2.3.2",
-        "tough-cookie": "^2.4.3",
-        "tslib": "^1.9.2",
-        "tunnel": "0.0.6",
-        "uuid": "^3.2.1",
-        "xml2js": "^0.4.19"
-      }
-    },
-    "@azure/ms-rest-nodeauth": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-0.9.3.tgz",
-      "integrity": "sha512-aFHRw/IHhg3I9ZJW+Va4L+sCirFHMVIu6B7lFdL5mGLfG3xC5vDIdd957LRXFgy2OiKFRUC0QaKknd0YCsQIqA==",
-      "requires": {
-        "@azure/ms-rest-azure-env": "^1.1.0",
-        "@azure/ms-rest-js": "^1.8.1",
-        "adal-node": "^0.1.22"
+        "tslib": "^1.9.3"
       }
     },
     "@babel/cli": {
@@ -1882,6 +1991,16 @@
         }
       }
     },
+    "@opencensus/web-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
+    },
+    "@opentelemetry/types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/types/-/types-0.2.0.tgz",
+      "integrity": "sha512-GtwNB6BNDdsIPAYEdpp3JnOGO/3AJxjPvny53s3HERBdXSJTGQw8IRhiaTEX0b3w9P8+FwFZde4k+qkjn67aVw=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2008,9 +2127,30 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg=="
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
+      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
+      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -2025,9 +2165,9 @@
       "dev": true
     },
     "@types/tunnel": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.0.tgz",
-      "integrity": "sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
       "requires": {
         "@types/node": "*"
       }
@@ -2365,29 +2505,6 @@
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
     },
-    "adal-node": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
-      "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
-      "requires": {
-        "@types/node": "^8.0.47",
-        "async": ">=0.6.0",
-        "date-utils": "*",
-        "jws": "3.x.x",
-        "request": ">= 2.52.0",
-        "underscore": ">= 1.3.1",
-        "uuid": "^3.1.0",
-        "xmldom": ">= 0.1.x",
-        "xpath.js": "~1.1.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.51",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.51.tgz",
-          "integrity": "sha512-cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q=="
-        }
-      }
-    },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -2397,6 +2514,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2659,6 +2777,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -2704,7 +2823,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -2717,11 +2837,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
-    },
-    "async": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
-      "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
     },
     "async-each": {
       "version": "1.0.3",
@@ -2753,34 +2868,20 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "axe-core": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.4.1.tgz",
       "integrity": "sha512-+EhIdwR0hF6aeMx46gFDUy6qyCfsL0DmBrV3Z+LxYbsOd8e1zBaPHa3f9Rbjsz2dEwSBkLw6TwML/CAIIAqRpw==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-      "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-        }
-      }
     },
     "azure-iot-amqp-base": {
       "version": "2.3.0",
@@ -3496,6 +3597,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -4100,7 +4202,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "ccount": {
       "version": "1.0.5",
@@ -4662,6 +4765,52 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -4878,6 +5027,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -4892,11 +5042,6 @@
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
       }
-    },
-    "date-utils": {
-      "version": "1.2.21",
-      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-      "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -5162,6 +5307,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -6032,17 +6178,20 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -6276,24 +6425,6 @@
       "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
       "dev": true
     },
-    "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -6309,12 +6440,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -7002,6 +7135,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -7158,12 +7292,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -7471,6 +7607,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -7868,8 +8005,7 @@
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-      "dev": true
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "ipaddr.js": {
       "version": "1.9.0",
@@ -7921,6 +8057,11 @@
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
       }
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -8056,6 +8197,11 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw=="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -8218,7 +8364,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-unc-path": {
       "version": "1.0.0",
@@ -8274,8 +8421,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -8286,7 +8432,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -9994,7 +10141,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsdom": {
       "version": "15.2.1",
@@ -10076,12 +10224,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10092,7 +10242,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -10110,6 +10261,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -10806,6 +10958,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "msal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-1.2.1.tgz",
+      "integrity": "sha512-Zo28eyRtT/Un+zcpMfPtTPD+eo/OqzsRER0k5dyk8Mje/K1oLlaEOAgZHlJs59Y2xyuVg8OrcKqSn/1MeNjZYw==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "multimatch": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
@@ -10917,6 +11077,11 @@
       "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-2.0.3.tgz",
       "integrity": "sha512-OY2QhGdf6jpYfHqS4vJwqF7aIBZkaMjMUkcHcskMPitvXLuYNGdQvgVWI/5yKwkmIdmhft3ounSJv+Re2yydng==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -11502,7 +11667,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -12150,7 +12316,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.2.1",
@@ -12841,7 +13008,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",
@@ -13281,6 +13449,7 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -13307,17 +13476,20 @@
         "extend": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+          "dev": true
         },
         "mime-db": {
           "version": "1.40.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.24",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
           "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+          "dev": true,
           "requires": {
             "mime-db": "1.40.0"
           }
@@ -13325,12 +13497,14 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -13531,13 +13705,13 @@
       }
     },
     "rhea-promise": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-0.1.15.tgz",
-      "integrity": "sha512-+6uilZXSJGyiqVeHQI3Krv6NTAd8cWRCY2uyCxmzR4/5IFtBqqFem1HV2OiwSj0Gu7OFChIJDfH2JyjN7J0vRA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-1.0.0.tgz",
+      "integrity": "sha512-odAjpbB/IpFFBenPDwPkTWMQldt+DUlMBH9yI48Ct5OgTeDuuQcBnlhB+YCc6g2z8+URiP2ejms88joEanNCaw==",
       "requires": {
         "debug": "^3.1.0",
-        "rhea": "^1.0.4",
-        "tslib": "^1.9.3"
+        "rhea": "^1.0.8",
+        "tslib": "^1.10.0"
       },
       "dependencies": {
         "debug": {
@@ -14402,6 +14576,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -15147,6 +15322,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -15254,6 +15430,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -15261,7 +15438,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -15348,11 +15526,6 @@
           }
         }
       }
-    },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "unherit": {
       "version": "1.1.3",
@@ -15699,6 +15872,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -15747,6 +15921,7 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
       "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+      "dev": true,
       "requires": {
         "inherits": "2.0.3"
       }
@@ -15911,6 +16086,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -16833,18 +17009,18 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",
@@ -16852,20 +17028,10 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
-    },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
-    },
-    "xpath.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "alex": "alex"
   },
   "dependencies": {
-    "@azure/event-hubs": "^2.1.1",
+    "@azure/event-hubs": "^5.0.1",
     "@babel/runtime": "^7.6.2",
     "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
     "azure-iothub": "^1.11.0",

--- a/public/js/components/App.vue
+++ b/public/js/components/App.vue
@@ -169,9 +169,11 @@ export default {
 
       const socket = io();
       socket.on("message", message => {
-        const deviceId = message.annotations["iothub-connection-device-id"];
+        const deviceId =
+          message.systemProperties["iothub-connection-device-id"];
         message.body.deviceId = deviceId;
-        message.body.enqueuedTime = message.annotations["iothub-enqueuedtime"];
+        message.body.enqueuedTime =
+          message.systemProperties["iothub-enqueuedtime"];
         if (this.messages.length > 500) this.messages.shift();
         this.messages.push(message.body);
       });

--- a/server.js
+++ b/server.js
@@ -13,7 +13,35 @@ const simHub = require("./lib/simHub");
 const routes = require("./lib/routes.js");
 
 // hub options
-const connectionString = process.env.CONNECTION_STRING;
+if (!process.env.IOTHUB_CONNECTION_STRING && process.env.CONNECTION_STRING) {
+  console.error(
+    "It looks like you recently upgraded electric-io and need to update your"
+  );
+  console.error("configuration.");
+  console.error("");
+  console.error(
+    "Previous versions of electric-io required the IoT Hub connection string"
+  );
+  console.error("in the CONNECTION_STRING environment variable.");
+  console.error("");
+  console.error(
+    "This version requires both the IoT Hub connection string and the Event"
+  );
+  console.error("Hub-compatible endpoint connection string:");
+  console.error("  IOTHUB_CONNECTION_STRING=...");
+  console.error("  EVENTHUB_CONNECTION_STRING=...");
+  console.error("");
+  console.error(
+    "For more information about how to configure these connection strings, go to"
+  );
+  console.error(
+    "https://github.com/noopkat/electric-io/blob/master/README.md#installation"
+  );
+
+  process.exit(1);
+}
+const iotHubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
+const eventHubConnectionString = process.env.EVENTHUB_CONNECTION_STRING;
 const consumerGroup = process.env.CONSUMER_GROUP || "$Default";
 const partitionFilter = process.env.PARTITION_FILTER || [];
 
@@ -38,10 +66,10 @@ function errorHandler(error) {
 }
 
 const hubOptions = {
-  connectionString,
+  iotHubConnectionString,
+  eventHubConnectionString,
   consumerGroup,
   partitionFilter,
-  startTime: Date.now(),
   receiveHandler,
   errorHandler
 };


### PR DESCRIPTION
Hi @noopkat and the electric-io community! :wave: :coffee: :v:

This pull request upgrades `@azure/event-hubs` to the latest version on npm: 5.0.1.

As mentioned on #196, we can no longer rely on the fantastically convenient static constructor `EventHubClient.createFromIotHubConnectionString`. This PR only goes as far as making electric-io functional again with version 5.0.1 of `@azure/event-hubs`. It does not address the connection strings issue and therefore electric-io now requires two connection strings in this PR: :cry: 
- the IoT Hub connection string which you already have, and
- the connection string of its [Event Hub-compatible endpoint](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin).

As Suz already lamented, this is a **breaking change** for electric-io users :sob: 

As such, I've included some things in the `server.js` and updated the `README.md` to ease the pain until we decide what to do about #196.

On the other hand, if the breaking changes prevent a merge then this PR can serve as a starting point where electric-io is at least functional with this version of `@azure/event-hubs`.

## Breaking changes

1. The `CONNECTION_STRING` environment variable (holding the IoT Hub connection string) is **renamed** to `IOTHUB_CONNECTION_STRING`.
2. **Added** a new environment variable `EVENTHUB_CONNECTION_STRING` for the connection string of the [Event Hub-compatible endpoint](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin) of the IoT Hub.

## Migration

If the server detects that `CONNECTION_STRING` is present but not `IOTHUB_CONNECTION_STRING`, it prints a message telling the user that this has changed and prints a link to the README.

To fix your configuration:

1.  Edit the `.env` file (or your Docker compose file) and rename the `CONNECTION_STRING` variable to `IOTHUB_CONNECTION_STRING`.
2.  Go to the Azure Portal, navigate to your IoT Hub, open the "Built-in endpoints" blade and copy your "Event Hub-compatible endpoint".
    ![azure-portal-iothub-eh-endpoint](https://user-images.githubusercontent.com/9063335/76156178-a0b65700-614a-11ea-9947-8ed92dc015ff.png)
3.  Back in `.env`, add a new variable `EVENTHUB_CONNECTION_STRING` and paste the Event Hub-compatible endpoint connection string copied in step 2.

## Message contract coupling

During this upgrade, I noticed the electric-io server sends the message object received from the Event Hub directly to the websocket as-is. This couples the UI component that is subscribed to the websocket to the Event Hub client library data structures.

For example, as part of the changes in `@azure/event-hubs`, the `annotations` property on this was renamed. This broke the event handler in `App.vue`.

In future, we may like to consider decoupling the message contract between the server and the browser from the Event Hubs types so that changes in the Event Hub client do not affect the browser app. This would probably be required to encourage contributions for alternative hubs too.

---

It also looks like prettier had some fun in the markdown files.
