### PR TITLE
Fix card settings not always being saved correctly

### DIFF
--- a/public/js/components/App.vue
+++ b/public/js/components/App.vue
@@ -169,6 +169,10 @@ export default {
 
       const socket = io();
       socket.on("message", message => {
+        if (!("systemProperties" in message)) {
+          return;
+        }
+
         const deviceId =
           message.systemProperties["iothub-connection-device-id"];
         message.body.deviceId = deviceId;

--- a/public/js/components/BaseCard.vue
+++ b/public/js/components/BaseCard.vue
@@ -45,10 +45,8 @@
 
     <card-form
       v-if="editingCard"
-      :editing="editingCard"
       :tile="tile"
       :device-list="deviceList"
-      :card-type="childCard"
       @save-settings="onSaveSettings"
       @cancel-editing="editingCard = false"
     />
@@ -310,6 +308,10 @@ export default {
     },
 
     stopDraggingCard() {
+      if (!this.draggingCard) {
+        return;
+      }
+
       this.draggingCard = false;
 
       if (this.cardHasBeenMoved) {

--- a/public/js/components/ButtonSettings.vue
+++ b/public/js/components/ButtonSettings.vue
@@ -2,11 +2,11 @@
   <div>
     <label>
       Device Id
-      <select id="deviceSelect" name="deviceId">
+      <select id="deviceSelect" name="deviceId" :value="tile.deviceId">
         <option
           v-for="(device, index) in deviceList"
           :key="`device-list-option-${index}`"
-          selected="device === tile.deviceId"
+          :value="device"
         >
           {{ device }}
         </option>
@@ -15,11 +15,15 @@
 
     <label>
       Call Type
-      <select id="callTypeSelect" v-model="tile.callType" name="callType">
+      <select
+        id="callTypeSelect"
+        v-model="tile.callType"
+        name="callType"
+        :value="tile.callType"
+      >
         <option
           v-for="option in typeOptions"
           :key="option.value"
-          :selected="option.value === tile.callType"
           :value="option.value"
         >
           {{ option.text }}

--- a/public/js/components/CardForm.vue
+++ b/public/js/components/CardForm.vue
@@ -31,7 +31,6 @@
 
 <script>
 import FormFields from "./FormFields";
-import { Script } from "vm";
 
 export default {
   name: "CardForm",
@@ -64,6 +63,7 @@ export default {
       formData.forEach((value, name) => {
         eventData[name] = value;
       });
+
       this.$emit("save-settings", eventData);
     },
 

--- a/public/js/components/LineChartSettings.vue
+++ b/public/js/components/LineChartSettings.vue
@@ -2,11 +2,15 @@
   <div>
     <label :for="`deviceId-${tile.id}`">
       Device Id
-      <select :id="`deviceId-${tile.id}`" name="deviceId">
+      <select
+        :id="`deviceId-${tile.id}`"
+        name="deviceId"
+        :value="tile.deviceId"
+      >
         <option
           v-for="(device, index) in deviceList"
           :key="`device-list-${index}`"
-          :selected="device === tile.deviceId"
+          :value="device"
         >
           {{ device }}
         </option>

--- a/public/js/components/NumberSettings.vue
+++ b/public/js/components/NumberSettings.vue
@@ -2,11 +2,15 @@
   <div>
     <label :for="`deviceId-${tile.id}`">
       Device Id
-      <select :id="`deviceId-${tile.id}`" name="deviceId">
+      <select
+        :id="`deviceId-${tile.id}`"
+        name="deviceId"
+        :value="tile.deviceId"
+      >
         <option
           v-for="(device, index) in deviceList"
           :key="`device-list-${index}`"
-          :selected="device === tile.deviceId"
+          :value="device"
         >
           {{ device }}
         </option>


### PR DESCRIPTION
Good day! :)

Fixing a bug you ran into last week on stream. I swear I fixed that one before, but that was obviously not the case.

I’m also the one who introduced the bug in the first place. It happened during the re-implementation of the card dragging logic.

## Changes

- Fixes a bug where the current content of a card settings form was lost on certain actions (e.g. clicking outside the card or clicking the save button). This made it look like the data wasn’t being saved. What actually happened was the form data being reset just when save was clicked.
- Adds an early return to the callback processing socket messages. It currently throws on a property systemProperties being accessed when it’s not always defined.