### PR TITLE
Ignore the user's .env file when running tests

### DIFF
--- a/lib/services/dashboard.service.js
+++ b/lib/services/dashboard.service.js
@@ -1,4 +1,3 @@
-require("dotenv").config();
 const debug = require("debug")("server");
 const fs = require("fs");
 const path = require("path");

--- a/server.js
+++ b/server.js
@@ -1,4 +1,9 @@
-require("dotenv").config();
+const dotenv = require("dotenv");
+
+if (process.env.NODE_ENV !== "test") {
+  dotenv.config();
+}
+
 const path = require("path");
 const http = require("http");
 const debug = require("debug")("server");
@@ -20,7 +25,7 @@ const consumerGroup = process.env.CONSUMER_GROUP || "$Default";
 const partitionFilter = process.env.PARTITION_FILTER || [];
 
 // server options
-const simulating = process.env.SIMULATING;
+const simulating = process.env.SIMULATING || "true";
 const platform = process.env.PLATFORM || "default";
 const port = process.env.PORT || 3000;
 


### PR DESCRIPTION
Hi noopcrew! :wave:

I have been enjoying the avrgirl-arduino activities on the stream, even though I know hardly anything about microcontrollers, but I've been learning!

This is a small change for Electric I/O :zap: that addresses issue #210.

---

# The problem

When you run `npm run test` with `SIMULATING=false`, many of the route tests fail. The status code assertions fail because the web server returns 404s instead of the expected status codes. This is because the live hub fails to start, causing the express routes not to be added.

To reproduce the issue, first configure your `.env` file to disable the simulator and set an IoT Hub connection string. The connection string does not have to be for a real IoT Hub.

```
CONNECTION_STRING='HostName=xxxxxxxxx.azure-devices.net;SharedAccessKeyName=xxxxxxxxx;SharedAccessKey=xxxxxxxxx'
CONSUMER_GROUP=''
SIMULATING=false
```

Then run the tests:

```
$ npm run test
⋮
  ● API endpoints › HubService endpoints › can’t queue message on device if the service produces an error

    expect(received).toBe(expected) // Object.is equality

    Expected: 500
    Received: 404
⋮
```

# The fix

This change ignores the configuration in the user's `.env` file when running tests, that is, when `NODE_ENV === "test"`.

The reason this fixes the route tests is because it forces the use of the simulation hub (and ignore any potential future configuration in `.env` that might also reduce the determinism of the tests).

Fixing the tests to pass even when using the live hub could be an enhancement for the future.